### PR TITLE
Fixes a few minor bugs

### DIFF
--- a/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
@@ -147,7 +147,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
           R.anim.enter_left,
           R.anim.exit_right
         )
-        .replace(R.id.fragment_container, fragmentClass.newInstance())
+        .replace(R.id.fragment_container, fragmentClass.newInstance(), tag)
         .addToBackStack(tag)
         .commit()
     }

--- a/app/src/test/java/com/github/ashutoshgngwr/noice/MainActivityTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/MainActivityTest.kt
@@ -166,4 +166,12 @@ class MainActivityTest {
     mainActivity.onNavigationItemSelected(RoboMenuItem(R.id.rate_on_play_store))
     assert(expectedIntent.filterEquals(shadowOf(mainActivity).peekNextStartedActivity()))
   }
+
+  @Test
+  fun `should not add a new instance for visible fragment on clicking its navigation item`() {
+    mainActivity.onNavigationItemSelected(RoboMenuItem(R.id.about))
+    assert(mainActivity.supportFragmentManager.backStackEntryCount == 2)
+    mainActivity.onNavigationItemSelected(RoboMenuItem(R.id.about))
+    assert(mainActivity.supportFragmentManager.backStackEntryCount == 2)
+  }
 }


### PR DESCRIPTION
### Issues
- Audio playback getting resumed on clicking Play action button in notification while audio focus was lost (temporarily/permanently)
- Audio playback not getting stopped at losing audio focus (caused Service to not request focus when playback was started again)
- MainActivity refreshing/re-adding visible screen on clicking selected navigation item

### Changes
- Added a lock to keep track of audio focus
- Stop rather than pause
- Missing `tag` in `FragmentTransaction#replace()` call

### Testing
- [x] Tested on a physical device
- [x] Added or modified unit test cases

