### PR TITLE
Fixes crash on opening about screen on Android 9+

### DIFF
--- a/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.MenuItem
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.view.GravityCompat
 import androidx.fragment.app.Fragment
 import com.github.ashutoshgngwr.noice.fragment.AboutFragment
@@ -27,6 +28,9 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    // force night mode and use custom theme with correct color values
+    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+
     setContentView(R.layout.activity_main)
 
     // setup toolbar to display animated drawer toggle button

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/AboutFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/AboutFragment.kt
@@ -67,9 +67,6 @@ class AboutFragment : Fragment() {
   }
 
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-    // force night mode and use custom theme with correct color values
-    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-
     return AboutPage(context).run {
       setImage(R.drawable.app_banner)
       setDescription(getString(R.string.app_description))

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/PresetFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/PresetFragment.kt
@@ -79,10 +79,12 @@ class PresetFragment : Fragment(), SoundManager.OnPlaybackStateChangeListener {
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    mRecyclerView = view.list_presets
-    mRecyclerView.setHasFixedSize(true)
-    mRecyclerView.adapter = PresetListAdapter(requireContext())
-    mRecyclerView.adapter?.registerAdapterDataObserver(mAdapterDataObserver)
+    mRecyclerView = view.list_presets.apply {
+      setHasFixedSize(true)
+      adapter = PresetListAdapter(requireContext()).apply {
+        registerAdapterDataObserver(mAdapterDataObserver)
+      }
+    }
 
     // manually call AdapterDataObserver#onChanged()
     mAdapterDataObserver.onChanged()

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SoundLibraryFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SoundLibraryFragment.kt
@@ -86,9 +86,11 @@ class SoundLibraryFragment : Fragment(), SoundManager.OnPlaybackStateChangeListe
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    mRecyclerView = view.list_sound
-    mRecyclerView.setHasFixedSize(true)
-    mRecyclerView.adapter = SoundListAdapter(requireContext())
+    mRecyclerView = view.list_sound.apply {
+      setHasFixedSize(true)
+      adapter = SoundListAdapter(requireContext())
+    }
+
     mSavePresetButton = view.fab_save_preset
     mSavePresetButton.setOnClickListener {
       SavePresetDialogFragment::class.java.newInstance().run {


### PR DESCRIPTION
### Changes
It was being caused by forced night mode in `AboutFragment` due to which activity was recreated on opening about screen. Forcing night mode on `MainActivity` instead, solved the problem.

### Testing
- [x] Tested on a physical device
- [x] Added or modified unit test cases

### Others
- Fixes #11 
- Connects N/A
