### PR TITLE
Adds null checks on RecyclerView in preset & sound library fragments

### DIFF
--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/PresetFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/PresetFragment.kt
@@ -27,7 +27,7 @@ class PresetFragment : Fragment(), SoundManager.OnPlaybackStateChangeListener {
   }
 
   private var mSoundManager: SoundManager? = null
-  private lateinit var mRecyclerView: RecyclerView
+  private var mRecyclerView: RecyclerView? = null
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   val mServiceConnection = object : ServiceConnection {
@@ -47,7 +47,7 @@ class PresetFragment : Fragment(), SoundManager.OnPlaybackStateChangeListener {
         }
       }
 
-      mRecyclerView.adapter.apply {
+      mRecyclerView?.adapter.apply {
         if (this is PresetListAdapter) {
           this.onPlaybackStateChanged()
         }
@@ -57,7 +57,7 @@ class PresetFragment : Fragment(), SoundManager.OnPlaybackStateChangeListener {
 
   private val mAdapterDataObserver = object : RecyclerView.AdapterDataObserver() {
     override fun onChanged() {
-      if (mRecyclerView.adapter?.itemCount ?: 0 > 0) {
+      if (mRecyclerView?.adapter?.itemCount ?: 0 > 0) {
         requireView().indicator_list_empty.visibility = View.GONE
       } else {
         requireView().indicator_list_empty.visibility = View.VISIBLE
@@ -91,7 +91,7 @@ class PresetFragment : Fragment(), SoundManager.OnPlaybackStateChangeListener {
   }
 
   override fun onPlaybackStateChanged(playbackState: Int) {
-    mRecyclerView.adapter.apply {
+    mRecyclerView?.adapter.apply {
       if (this is PresetListAdapter) {
         this.onPlaybackStateChanged()
       }
@@ -99,7 +99,7 @@ class PresetFragment : Fragment(), SoundManager.OnPlaybackStateChangeListener {
   }
 
   override fun onDestroyView() {
-    mRecyclerView.adapter?.unregisterAdapterDataObserver(mAdapterDataObserver)
+    mRecyclerView?.adapter?.unregisterAdapterDataObserver(mAdapterDataObserver)
     super.onDestroyView()
   }
 
@@ -177,7 +177,7 @@ class PresetFragment : Fragment(), SoundManager.OnPlaybackStateChangeListener {
               }
 
               @Suppress("DEPRECATION")
-              Snackbar.make(mRecyclerView, R.string.preset_deleted, Snackbar.LENGTH_LONG)
+              Snackbar.make(requireView(), R.string.preset_deleted, Snackbar.LENGTH_LONG)
                 .setBackgroundTint(resources.getColor(R.color.colorPrimary))
                 .setAction(R.string.dismiss) { }
                 .show()

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SoundLibraryFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SoundLibraryFragment.kt
@@ -37,7 +37,7 @@ class SoundLibraryFragment : Fragment(), SoundManager.OnPlaybackStateChangeListe
   private var mSoundManager: SoundManager? = null
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-  lateinit var mRecyclerView: RecyclerView
+  var mRecyclerView: RecyclerView? = null
 
   private lateinit var mSavePresetButton: FloatingActionButton
 
@@ -60,7 +60,7 @@ class SoundLibraryFragment : Fragment(), SoundManager.OnPlaybackStateChangeListe
       }
 
       // once service is connected, update playback state in UI
-      mRecyclerView.adapter.apply {
+      mRecyclerView?.adapter.apply {
         if (this is SoundListAdapter) {
           this.onPlaybackStateChanged()
         }
@@ -134,7 +134,7 @@ class SoundLibraryFragment : Fragment(), SoundManager.OnPlaybackStateChangeListe
       SoundManager.OnPlaybackStateChangeListener.STATE_PLAYBACK_STOPPED,
       SoundManager.OnPlaybackStateChangeListener.STATE_PLAYBACK_UPDATED -> {
         Log.d(TAG, "Playback state changed. Refreshing sound list...")
-        mRecyclerView.adapter.apply {
+        mRecyclerView?.adapter.apply {
           if (this is SoundListAdapter) {
             this.onPlaybackStateChanged()
           }


### PR DESCRIPTION
### Changes
Temporary duct tape fix for app crash due to `MainActivity` recreation on opening `AboutFragment`.

### Testing
- [ ] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes N/A
- Connects #11
