### PR TITLE
Fixes broken CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: android
+dist: trusty
 jdk: oraclejdk8
 sudo: required
 


### PR DESCRIPTION
### Changes
Explicitly add `dist: trusty` in Travis config. Android builds are currently supported only for trusty in Travis CI. See [this](https://docs.travis-ci.com/user/languages/android/)!

### Testing
- [ ] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes N/A
- Connects N/A
