### PR TITLE
Fixes crash/noplayback scenarios on playing randomized sounds

### DIFF
--- a/app/src/main/res/layout/layout_list_item__sound.xml
+++ b/app/src/main/res/layout/layout_list_item__sound.xml
@@ -87,7 +87,8 @@
           android:layout_width="0dp"
           android:layout_height="wrap_content"
           android:layout_weight="1"
-          android:max="240"/>
+          android:max="240"
+          android:min="10"/>
 
       </LinearLayout>
 


### PR DESCRIPTION
### Context

Earlier seeking the time period to minimum was setting time period to 0.
Time period is used as a modulo divisor when scheduling randomized playback.
This was causing division by zero errors.

### Changes

- Set min value on time period seekbar

### Testing
- [x] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes #48 
