### PR TITLE
Attempts to fix build matrix for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ stages:
 before_script:
   - echo y | sdkmanager "system-images;$TEST_PLATFORM;google_apis;x86" > /dev/null
   - echo no | avdmanager create avd -f -n "$TEST_PLATFORM" -k "system-images;$TEST_PLATFORM;google_apis;x86" -c 500M
-  - emulator -avd "$TEST_PLATFORM" -memory 4096 -no-audio -no-snapshot -no-window -camera-back none -camera-front none &
+  - emulator -avd "$TEST_PLATFORM" -memory 4096 -no-boot-anim -no-audio -no-snapshot -no-window -camera-back none -camera-front none &
   - >- # ensures that animations are disabled on the device and device is always awake.
       adb wait-for-device shell '
         while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
     - ANDROID_HOME="$HOME/android-sdk"
     - PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/tools:$PATH"
   matrix:
-    - TEST_PLATFORM=android-21
+    - TEST_PLATFORM=android-22
     - TEST_PLATFORM=android-23
-    - TEST_PLATFORM=android-24
-    - TEST_PLATFORM=android-26
+    - TEST_PLATFORM=android-25
+    - TEST_PLATFORM=android-27
     - TEST_PLATFORM=android-28
     - TEST_PLATFORM=android-29
 


### PR DESCRIPTION
### Changes

Most of the time build jobs fail randomly due to slowness of emulators. Hopefully this aids in fixing that.

- Changes Android versions in the build matrix
- Disables boot animation for emulator devices

### Testing
- [ ] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes #0
- Connects #0
