### PR TITLE
Fixes unwanted gap in looping sounds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ dependencies {
   implementation 'com.google.code.gson:gson:2.8.6'
   implementation 'com.github.medyo:android-about-page:1.2.5'
   implementation 'org.greenrobot:eventbus:3.1.1'
+  implementation 'com.google.android.exoplayer:exoplayer-core:2.11.3'
 
   androidTestImplementation 'junit:junit:4.13'
   androidTestImplementation 'androidx.test:core:1.2.0'

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/MainActivityTest.kt
@@ -21,7 +21,6 @@ import com.github.ashutoshgngwr.noice.fragment.AboutFragment
 import com.github.ashutoshgngwr.noice.fragment.PresetFragment
 import com.github.ashutoshgngwr.noice.fragment.SoundLibraryFragment
 import kotlinx.android.synthetic.main.activity_main.*
-import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/PresetFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/PresetFragmentTest.kt
@@ -69,7 +69,6 @@ class PresetFragmentTest {
         "birds" to Playback(
           it.requireContext(),
           requireNotNull(Sound.LIBRARY["birds"]),
-          123,
           AudioAttributesCompat.Builder().build()
         )
       )
@@ -91,7 +90,6 @@ class PresetFragmentTest {
       playback = Playback(
         it.requireContext(),
         requireNotNull(Sound.LIBRARY["birds"]),
-        123,
         AudioAttributesCompat.Builder().build()
       )
 
@@ -116,7 +114,6 @@ class PresetFragmentTest {
       val playback = Playback(
         it.requireContext(),
         requireNotNull(Sound.LIBRARY["birds"]),
-        123,
         AudioAttributesCompat.Builder().build()
       )
 
@@ -139,7 +136,6 @@ class PresetFragmentTest {
       val playback = Playback(
         it.requireContext(),
         requireNotNull(Sound.LIBRARY["birds"]),
-        123,
         AudioAttributesCompat.Builder().build()
       )
 
@@ -176,12 +172,15 @@ class PresetFragmentTest {
     fun testSavePresets() {
       val ctx = InstrumentationRegistry.getInstrumentation().targetContext
       val playback = Playback(
-        ctx, requireNotNull(Sound.LIBRARY["birds"]), 123, AudioAttributesCompat.Builder().build()
+        ctx, requireNotNull(Sound.LIBRARY["birds"]), AudioAttributesCompat.Builder().build()
       )
       // save preset to user preferences
       val preset = PresetFragment.Preset("test", arrayOf(playback))
       PresetFragment.Preset.appendToUserPreferences(ctx, preset)
-      assertEquals(playback, PresetFragment.Preset.readAllFromUserPreferences(ctx)[0].playbackStates[0])
+      assertEquals(
+        playback,
+        PresetFragment.Preset.readAllFromUserPreferences(ctx)[0].playbackStates[0]
+      )
     }
   }
 }

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/SavePresetDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/SavePresetDialogFragmentTest.kt
@@ -67,7 +67,6 @@ class SavePresetDialogFragmentTest {
           Playback(
             InstrumentationRegistry.getInstrumentation().targetContext,
             requireNotNull(Sound.LIBRARY["birds"]),
-            0x92,
             AudioAttributesCompat.Builder().build()
           )
         )
@@ -96,7 +95,6 @@ class SavePresetDialogFragmentTest {
           Playback(
             InstrumentationRegistry.getInstrumentation().targetContext,
             requireNotNull(Sound.LIBRARY["birds"]),
-            0x92,
             AudioAttributesCompat.Builder().build()
           )
         )

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/SoundLibraryFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/SoundLibraryFragmentTest.kt
@@ -149,7 +149,6 @@ class SoundLibraryFragmentTest {
           "birds" to Playback(
             InstrumentationRegistry.getInstrumentation().targetContext,
             requireNotNull(Sound.LIBRARY["birds"]),
-            123,
             AudioAttributesCompat.Builder().build()
           )
         )
@@ -175,7 +174,6 @@ class SoundLibraryFragmentTest {
       fakePlayback = Playback(
         InstrumentationRegistry.getInstrumentation().targetContext,
         requireNotNull(Sound.LIBRARY["birds"]),
-        123,
         AudioAttributesCompat.Builder().build()
       )
 
@@ -201,7 +199,6 @@ class SoundLibraryFragmentTest {
       fakePlayback = Playback(
         InstrumentationRegistry.getInstrumentation().targetContext,
         requireNotNull(Sound.LIBRARY["rolling_thunder"]),
-        123,
         AudioAttributesCompat.Builder().build()
       )
 
@@ -247,13 +244,11 @@ class SoundLibraryFragmentTest {
           "birds" to Playback(
             InstrumentationRegistry.getInstrumentation().targetContext,
             requireNotNull(Sound.LIBRARY["birds"]),
-            123,
             AudioAttributesCompat.Builder().build()
           ),
           "rolling_thunder" to Playback(
             InstrumentationRegistry.getInstrumentation().targetContext,
             requireNotNull(Sound.LIBRARY["rolling_thunder"]),
-            123,
             AudioAttributesCompat.Builder().build()
           )
         )
@@ -274,13 +269,11 @@ class SoundLibraryFragmentTest {
         "birds" to Playback(
           InstrumentationRegistry.getInstrumentation().targetContext,
           requireNotNull(Sound.LIBRARY["birds"]),
-          123,
           AudioAttributesCompat.Builder().build()
         ),
         "rolling_thunder" to Playback(
           InstrumentationRegistry.getInstrumentation().targetContext,
           requireNotNull(Sound.LIBRARY["rolling_thunder"]),
-          123,
           AudioAttributesCompat.Builder().build()
         )
       )
@@ -302,7 +295,6 @@ class SoundLibraryFragmentTest {
         "birds" to Playback(
           InstrumentationRegistry.getInstrumentation().targetContext,
           requireNotNull(Sound.LIBRARY["birds"]),
-          123,
           AudioAttributesCompat.Builder().build()
         )
       )

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/sound/PlaybackTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/sound/PlaybackTest.kt
@@ -1,24 +1,20 @@
 package com.github.ashutoshgngwr.noice.sound
 
 import android.content.Context
-import android.media.AudioManager
 import androidx.media.AudioAttributesCompat
-import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import com.google.android.exoplayer2.ExoPlayer
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.Thread.sleep
 
 
 @RunWith(AndroidJUnit4::class)
 class PlaybackTest {
 
   private lateinit var context: Context
-  private lateinit var audioManager: AudioManager
   private lateinit var audioAttributes: AudioAttributesCompat
   private lateinit var loopingSound: Sound
   private lateinit var nonLoopingSound: Sound
@@ -26,105 +22,102 @@ class PlaybackTest {
   @Before
   fun setup() {
     context = InstrumentationRegistry.getInstrumentation().targetContext
-    audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     audioAttributes = AudioAttributesCompat.Builder().build()
     loopingSound = requireNotNull(Sound.LIBRARY["birds"])
     nonLoopingSound = requireNotNull(Sound.LIBRARY["rolling_thunder"])
   }
 
   @Test
-  @UiThreadTest
   fun testLoopingPlayback() {
-    val p = Playback(context, loopingSound, audioManager.generateAudioSessionId(), audioAttributes)
+    var p: Playback? = null
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      p = Playback(context, loopingSound, audioAttributes)
+    }
 
     // should be set to looping on object initialization
-    assertTrue(p.mediaPlayer.isLooping)
+    assertEquals(ExoPlayer.REPEAT_MODE_ONE, requireNotNull(p).player.repeatMode)
     // shouldn't be playing by default
-    assertFalse(p.isPlaying)
-    assertFalse(p.mediaPlayer.isPlaying)
-    p.play()
+    assertFalse(requireNotNull(p).isPlaying)
+    assertFalse(requireNotNull(p).player.playWhenReady)
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      requireNotNull(p).play()
+    }
 
     // should start playing the MediaPlayer
-    assertTrue(p.isPlaying)
-    assertTrue(p.mediaPlayer.isPlaying)
+    assertTrue(requireNotNull(p).isPlaying)
+    assertTrue(requireNotNull(p).player.playWhenReady)
   }
 
   @Test
-  @UiThreadTest
   fun testNonLoopingPlayback() {
-    val p = Playback(
-      context,
-      nonLoopingSound,
-      audioManager.generateAudioSessionId(),
-      audioAttributes
-    )
+    var p: Playback? = null
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      p = Playback(context, nonLoopingSound, audioAttributes)
+    }
 
     // should be set to looping on object initialization
-    assertFalse(p.mediaPlayer.isLooping)
+    assertNotEquals(ExoPlayer.REPEAT_MODE_ONE, requireNotNull(p).player.repeatMode)
     // shouldn't be playing by default
-    assertFalse(p.isPlaying)
-    assertFalse(p.mediaPlayer.isPlaying)
+    assertFalse(requireNotNull(p).isPlaying)
+    assertFalse(requireNotNull(p).player.playWhenReady)
     // shouldn't add any callbacks to the handler
-    assertFalse(p.handler.hasCallbacks(p))
+    assertFalse(requireNotNull(p).handler.hasCallbacks(requireNotNull(p)))
 
-    p.play()
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      requireNotNull(p).play()
+    }
 
     // should start playing the MediaPlayer
-    assertTrue(p.isPlaying)
-    assertTrue(p.mediaPlayer.isPlaying)
+    assertTrue(requireNotNull(p).isPlaying)
+    assertTrue(requireNotNull(p).player.playWhenReady)
     // should add itself as a callback to the handler
-    assertTrue(p.handler.hasCallbacks(p))
-
-    // wait for the sound to finish playing once
-    sleep(p.mediaPlayer.duration.toLong() + 500L)
-
-    // should stop the media player's playback. this should always pass since minimum delay for
-    // replaying a sound is always more than a few seconds. Also playback's state should be playing.
-    assertTrue(p.isPlaying)
-    assertFalse(p.mediaPlayer.isPlaying)
+    assertTrue(requireNotNull(p).handler.hasCallbacks(requireNotNull(p)))
   }
 
   @Test
-  @UiThreadTest
   fun testStopLoopingPlayback() {
-    val p = Playback(context, loopingSound, audioManager.generateAudioSessionId(), audioAttributes)
-    p.play()
+    var p: Playback? = null
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      p = Playback(context, loopingSound, audioAttributes)
+      requireNotNull(p).play()
+    }
 
     // should start playing the MediaPlayer
-    assertTrue(p.isPlaying)
-    assertTrue(p.mediaPlayer.isPlaying)
+    assertTrue(requireNotNull(p).isPlaying)
+    assertTrue(requireNotNull(p).player.playWhenReady)
 
-    p.stop()
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      requireNotNull(p).stop()
+    }
 
     // should stop
-    assertFalse(p.isPlaying)
-    assertFalse(p.mediaPlayer.isPlaying)
+    assertFalse(requireNotNull(p).isPlaying)
+    assertFalse(requireNotNull(p).player.playWhenReady)
   }
 
   @Test
-  @UiThreadTest
   fun testStopNonLoopingPlayback() {
-    val p = Playback(
-      context,
-      nonLoopingSound,
-      audioManager.generateAudioSessionId(),
-      audioAttributes
-    )
-
-    p.play()
+    var p: Playback? = null
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      p = Playback(context, nonLoopingSound, audioAttributes)
+      requireNotNull(p).play()
+    }
 
     // should start playing the MediaPlayer
-    assertTrue(p.isPlaying)
-    assertTrue(p.mediaPlayer.isPlaying)
+    assertTrue(requireNotNull(p).isPlaying)
+    assertTrue(requireNotNull(p).player.playWhenReady)
     // should add itself as a callback to the handler
-    assertTrue(p.handler.hasCallbacks(p))
+    assertTrue(requireNotNull(p).handler.hasCallbacks(requireNotNull(p)))
 
-    p.stop()
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      requireNotNull(p).stop()
+    }
 
     // should stop
-    assertFalse(p.isPlaying)
-    assertFalse(p.mediaPlayer.isPlaying)
+    assertFalse(requireNotNull(p).isPlaying)
+    assertFalse(requireNotNull(p).player.playWhenReady)
     // should remove itself as a callback from the handler
-    assertFalse(p.handler.hasCallbacks(p))
+    assertFalse(requireNotNull(p).handler.hasCallbacks(requireNotNull(p)))
   }
 }


### PR DESCRIPTION
Earlier, we were using Android's MediaPlayer for managing
playbacks. Android's MediaPlayer implementation doesn't
support true gapless playback for looping sounds. i.e.,
there is noticeable gap between loops.

### Changes

Change playback backend to ExoPlayer.

### Testing
- [x] Tested on a physical device
- [x] Added or modified unit test cases

### Others
- Fixes N/A
- Connects N/A
