### PR TITLE
Adds view null check in onSaveInstanceState() of SleepTimerFragment

### DIFF
--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SleepTimerFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SleepTimerFragment.kt
@@ -42,6 +42,7 @@ class SleepTimerFragment : Fragment() {
 
   @Suppress("DEPRECATION")
   override fun onSaveInstanceState(outState: Bundle) {
+    view ?: return
     val timePicker = requireView().time_picker
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       outState.putInt(KEY_HOUR, timePicker.hour)


### PR DESCRIPTION
### Changes

The app would sometimes crash with following crash log. It is not clear why `onSaveInstanceState()` is being called when view is `null`. Regardless, it's nothing that a null check can not solve.

```
java.lang.IllegalStateException: Fragment did not return a View from onCreateView() or this was called before onCreateView().
	at androidx.fragment.app.Fragment.requireView(Fragment.java:2)
	at com.github.ashutoshgngwr.noice.fragment.SleepTimerFragment.d(SleepTimerFragment.java:2)
	at androidx.fragment.app.Fragment.performSaveInstanceState(Fragment.java:5)
	at androidx.fragment.app.FragmentManagerImpl.saveFragmentBasicState(FragmentManagerImpl.java:5)
	at androidx.fragment.app.FragmentManagerImpl.saveAllState(FragmentManagerImpl.java:5)
	at androidx.fragment.app.FragmentController.saveAllState(FragmentController.java:3)
	at androidx.fragment.app.FragmentActivity.onSaveInstanceState(FragmentActivity.java:3)
	at androidx.appcompat.app.AppCompatActivity.onSaveInstanceState(AppCompatActivity.java:0)
	at android.app.Activity.performSaveInstanceState(Activity.java:1555)
	at android.app.Instrumentation.callActivityOnSaveInstanceState(Instrumentation.java:1392)
	at android.app.ActivityThread.callCallActivityOnSaveInstanceState(ActivityThread.java:4941)
	at android.app.ActivityThread.performStopActivityInner(ActivityThread.java:4229)
	at android.app.ActivityThread.handleStopActivity(ActivityThread.java:4288)
	at android.app.ActivityThread.-wrap25(Unknown Source:0)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1730)
	at android.os.Handler.dispatchMessage(Handler.java:105)
	at android.os.Looper.loop(Looper.java:164)
	at android.app.ActivityThread.main(ActivityThread.java:6938)
	at java.lang.reflect.Method.invoke(Method.java)
	at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:327)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1374)
```

### Testing
- [ ] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes #0
- Connects #0
