### PR TITLE
Fixes volume serialization/deserialization to/from JSON in Playback

### DIFF
--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/sound/PlaybackTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/sound/PlaybackTest.kt
@@ -5,6 +5,7 @@ import androidx.media.AudioAttributesCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.exoplayer2.ExoPlayer
+import com.google.gson.GsonBuilder
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -119,5 +120,23 @@ class PlaybackTest {
     assertFalse(requireNotNull(p).player.playWhenReady)
     // should remove itself as a callback from the handler
     assertFalse(requireNotNull(p).handler.hasCallbacks(requireNotNull(p)))
+  }
+
+  @Test
+  fun testJsonSerializationDeserialization() {
+    val gson = GsonBuilder()
+      .excludeFieldsWithoutExposeAnnotation()
+      .create()
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      val p = Playback(context, nonLoopingSound, audioAttributes)
+      p.timePeriod = 120
+      p.setVolume(14)
+
+      val json = gson.toJson(p)
+      val anotherP = gson.fromJson(json, Playback::class.java)
+      assertEquals(p.volume, anotherP.volume)
+      assertEquals(p.timePeriod, anotherP.timePeriod)
+    }
   }
 }


### PR DESCRIPTION
This was breaking compatibility after 0.3.0. Older versions used a Float data type for volumes while newer versions started using Int. This was an oversight and hence the fix.

### Changes

Add a custom Serializer and Deserializer for volume field in playback

### Testing
- [x] Tested on a physical device
- [x] Added or modified unit test cases

### Others
- Fixes #0
- Connects #0
