### PR TITLE
Fixes force close caused by the JSON deserialization after upgrading from 0.2.7 or older

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,5 +1,28 @@
+# EventBus rules
 -keepattributes *Annotation*
 -keepclassmembers class * {
     @org.greenrobot.eventbus.Subscribe <methods>;
 }
 -keep enum org.greenrobot.eventbus.ThreadMode { *; }
+
+# GSON rules
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+# For using GSON @Expose annotation, already present in EventBus rules
+# -keepattributes *Annotation*
+
+# Gson specific classes
+-dontwarn sun.misc.**
+
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * implements com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+# Prevent R8 from leaving Data object members always null
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/PresetFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/PresetFragment.kt
@@ -17,6 +17,7 @@ import com.github.ashutoshgngwr.noice.sound.PlaybackControlEvents
 import com.google.android.material.snackbar.Snackbar
 import com.google.gson.GsonBuilder
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
 import kotlinx.android.synthetic.main.fragment_preset_list.view.*
 import kotlinx.android.synthetic.main.layout_list_item__preset.view.*
 import org.greenrobot.eventbus.EventBus
@@ -163,7 +164,12 @@ class PresetFragment : Fragment() {
     }
   }
 
-  data class Preset(@Expose var name: String, @Expose val playbackStates: Array<Playback>) {
+  // curious about the weird serialized names? see https://github.com/ashutoshgngwr/noice/issues/110
+  // and https://github.com/ashutoshgngwr/noice/pulls/117
+  data class Preset(
+    @Expose @SerializedName("a") var name: String,
+    @Expose @SerializedName("b") val playbackStates: Array<Playback>
+  ) {
 
     init {
       playbackStates.sortBy { T -> T.soundKey }

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/sound/Playback.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/sound/Playback.kt
@@ -14,6 +14,7 @@ import com.google.android.exoplayer2.upstream.DataSource
 import com.google.gson.*
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.JsonAdapter
+import com.google.gson.annotations.SerializedName
 import java.lang.reflect.Type
 import kotlin.random.Random.Default.nextInt
 
@@ -70,19 +71,23 @@ class Playback(
 
   }
 
-
+  // curious about the weird serialized names? see https://github.com/ashutoshgngwr/noice/issues/110
+  // and https://github.com/ashutoshgngwr/noice/pulls/117
   @Expose
+  @SerializedName("b")
   @JsonAdapter(value = VolumeSerializer::class)
   var volume = DEFAULT_VOLUME
     private set
 
   @Expose
+  @SerializedName("c")
   var timePeriod = DEFAULT_TIME_PERIOD
 
   var isPlaying = false
     private set
 
   @Expose
+  @SerializedName("a")
   val soundKey = sound.key
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)


### PR DESCRIPTION
### Changes

- Added missing proguard rules for Gson library
- Explicitly specify field names to use for serialization/deserialization from older versions

### Testing
- [x] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes #110
- Connects N/A
