### PR TITLE
Fixes inconsistencies in app's appearance

### DIFF
--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SavePresetDialogFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SavePresetDialogFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.view.ContextThemeWrapper
 import com.github.ashutoshgngwr.noice.R
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.android.synthetic.main.dialog_save_preset.view.*
@@ -19,7 +20,11 @@ class SavePresetDialogFragment : BottomSheetDialogFragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View? {
-    return inflater.inflate(R.layout.dialog_save_preset, container, false)
+    // see https://github.com/material-components/material-components-android/issues/99
+    val ctxWrapper = ContextThemeWrapper(requireContext(), R.style.AppTheme)
+    return inflater
+      .cloneInContext(ctxWrapper)
+      .inflate(R.layout.dialog_save_preset, container, false)
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/res/layout/dialog_save_preset.xml
+++ b/app/src/main/res/layout/dialog_save_preset.xml
@@ -12,7 +12,7 @@
   app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
 
   <TextView
-    style="@style/TextAppearance.AppCompat.Title.Inverse"
+    style="@style/TextAppearance.AppCompat.Headline"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:text="@string/save_preset"/>
@@ -31,7 +31,6 @@
       android:maxLines="1"
       android:inputType="text"
       android:hint="@string/name"
-      android:textColor="@android:color/white"
       android:importantForAutofill="no"
       tools:targetApi="o"/>
 

--- a/app/src/main/res/layout/layout_list_item__preset.xml
+++ b/app/src/main/res/layout/layout_list_item__preset.xml
@@ -44,6 +44,7 @@
       android:layout_height="wrap_content"
       android:background="?android:selectableItemBackgroundBorderless"
       android:src="@drawable/ic_action_delete"
+      android:tint="@color/colorAccent"
       android:contentDescription="@string/delete_preset"/>
 
   </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,12 @@
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccent</item>
     <item name="android:windowBackground">@color/colorBackground</item>
+    <item name="alertDialogTheme">@style/AppAlertDialogTheme</item>
+  </style>
+
+  <style name="AppAlertDialogTheme" parent="Theme.AppCompat.DayNight.Dialog.Alert">
+    <item name="android:windowBackground">@color/colorBackground</item>
+    <item name="colorAccent">@color/colorAccent</item>
   </style>
 
 </resources>


### PR DESCRIPTION
### Changes
- Fix SavePresetDialogFragment's appearance for light theme. See #126 
- Fix AlertDialog appearance throughout apps
- Fix delete button color in PresetFragment for light theme


### Testing
- [x] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes #126 
- Connects #0
