### PR TITLE
Fixes ArrayIndexOutOfBounds in SoundLibraryFragment's ViewHolder

### DIFF
--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SoundLibraryFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/SoundLibraryFragment.kt
@@ -189,12 +189,12 @@ class SoundLibraryFragment : Fragment() {
         view.seekbar_time_period.setOnSeekBarChangeListener(seekBarChangeListener)
 
         view.button_play.setOnClickListener {
-          val soundKey = dataSet[adapterPosition].key
+          val sound = dataSet.getOrNull(adapterPosition) ?: return@setOnClickListener
 
-          if (playbacks.containsKey(soundKey)) {
-            eventBus.post(PlaybackControlEvents.StopPlaybackEvent(soundKey))
+          if (playbacks.containsKey(sound.key)) {
+            eventBus.post(PlaybackControlEvents.StopPlaybackEvent(sound.key))
           } else {
-            eventBus.post(PlaybackControlEvents.StartPlaybackEvent(soundKey))
+            eventBus.post(PlaybackControlEvents.StartPlaybackEvent(sound.key))
           }
         }
       }


### PR DESCRIPTION
Google Play Store reported a weird crash with following log. It is very infrequent and only happens on some devices.

```
java.lang.ArrayIndexOutOfBoundsException:
at com.github.ashutoshgngwr.noice.fragment.SoundLibraryFragment$SoundListAdapter$ViewHolder$1.onClick (SoundLibraryFragment.java:2)
  at android.view.View.performClick (View.java:5280)
  at android.view.View$PerformClick.run (View.java:21239)
  at android.os.Handler.handleCallback (Handler.java:739)
  at android.os.Handler.dispatchMessage (Handler.java:95)
  at android.os.Looper.loop (Looper.java:234)
  at android.app.ActivityThread.main (ActivityThread.java:5526)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:726)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:616)
```

### Changes

- Add a bound check on `adapterPosition` in play button on-click listener

### Testing
- [ ] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes _n/a_
- Connects _n/a_
