### PR TITLE
Fixes play button not responding to clicks

### DIFF
--- a/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
@@ -79,7 +79,10 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     // volume control to type "media"
     volumeControlStream = AudioManager.STREAM_MUSIC
+  }
 
+  override fun onResume() {
+    super.onResume()
     // start the media player service
     startService(Intent(this, MediaPlayerService::class.java))
   }


### PR DESCRIPTION
Issue #159 happens because service is stopped when activity is paused
for sometime after stopping the playback.

### Changes

- Move `startService` call from `onCreate` to `onResume`

### Testing
- [x] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes #159 
- Connects _N/A_
