### PR TITLE
Fixes stutter during fragment change animation

### DIFF
--- a/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
@@ -143,7 +143,11 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
       }
     }
 
-    layout_main.closeDrawer(GravityCompat.START)
+    // hack to avoid stuttering in animations
+    layout_main.postDelayed({
+      layout_main.closeDrawer(GravityCompat.START)
+    }, 150)
+
     return true
   }
 

--- a/app/src/main/res/anim/enter_left.xml
+++ b/app/src/main/res/anim/enter_left.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shareInterpolator="false">
+<set xmlns:android="http://schemas.android.com/apk/res/android">
 
   <translate
+    android:duration="300"
     android:fromXDelta="-100%"
-    android:toXDelta="0%"
     android:fromYDelta="0%"
-    android:toYDelta="0%"
-    android:duration="300" />
+    android:toXDelta="0%"
+    android:toYDelta="0%" />
 
 </set>

--- a/app/src/main/res/anim/enter_right.xml
+++ b/app/src/main/res/anim/enter_right.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shareInterpolator="false">
+<set xmlns:android="http://schemas.android.com/apk/res/android">
 
   <translate
+    android:duration="300"
     android:fromXDelta="100%"
-    android:toXDelta="0%"
     android:fromYDelta="0%"
-    android:toYDelta="0%"
-    android:duration="300" />
+    android:toXDelta="0%"
+    android:toYDelta="0%" />
 
 </set>

--- a/app/src/main/res/anim/exit_left.xml
+++ b/app/src/main/res/anim/exit_left.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shareInterpolator="false">
+  android:startOffset="50">
 
   <translate
+    android:duration="300"
     android:fromXDelta="0%"
-    android:toXDelta="-100%"
     android:fromYDelta="0%"
-    android:toYDelta="0%"
-    android:duration="300" />
+    android:toXDelta="-100%"
+    android:toYDelta="0%" />
 
 </set>

--- a/app/src/main/res/anim/exit_right.xml
+++ b/app/src/main/res/anim/exit_right.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shareInterpolator="false">
+  android:startOffset="50">
 
   <translate
+    android:duration="300"
     android:fromXDelta="0%"
-    android:toXDelta="100%"
     android:fromYDelta="0%"
-    android:toYDelta="0%"
-    android:duration="300" />
+    android:toXDelta="100%"
+    android:toYDelta="0%" />
 
 </set>


### PR DESCRIPTION
### Changes

Added a delay to close drawer in navigation item selected listener to avoid animation stutter. The delay prevents the fragment change and navigation drawer close animation
to start at the same time which was the cause of stutter.


### Testing
- [x] Tested on a physical device
- [ ] Added or modified unit test cases
