### PR TITLE
Fixes crash on starting service when resuming app from background

### DIFF
--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/MainActivityTest.kt
@@ -3,16 +3,20 @@ package com.github.ashutoshgngwr.noice
 import android.content.Intent
 import android.net.Uri
 import android.view.Gravity
+import android.view.View
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.FragmentManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.DrawerActions
 import androidx.test.espresso.contrib.DrawerMatchers.isClosed
 import androidx.test.espresso.contrib.NavigationViewActions
+import androidx.test.espresso.idling.CountingIdlingResource
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.filterEquals
@@ -97,7 +101,7 @@ class MainActivityTest {
         .check(matches(isDisplayed()))
         .perform(click())
 
-      InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+      onView(withId(R.id.layout_main)).check(matches(isDisplayed())) // wait for activity to recreate
       assertEquals(nightModes[i], AppCompatDelegate.getDefaultNightMode())
     }
   }
@@ -170,23 +174,38 @@ class MainActivityTest {
 
   @Test
   fun testBackNavigation() {
+    val drawerIdlingResource = CountingIdlingResource("CloseNavigationDrawer")
+    activityScenario.onActivity {
+      it.layout_main.addDrawerListener(object : DrawerLayout.DrawerListener {
+        override fun onDrawerSlide(drawerView: View, slideOffset: Float) = Unit
+        override fun onDrawerClosed(drawerView: View) = Unit
+        override fun onDrawerOpened(drawerView: View) = Unit
+        override fun onDrawerStateChanged(newState: Int) {
+          if (newState == DrawerLayout.STATE_IDLE) {
+            drawerIdlingResource.decrement()
+          } else {
+            drawerIdlingResource.increment()
+          }
+        }
+      })
+    }
+
+    IdlingRegistry.getInstance().register(drawerIdlingResource)
     onView(withId(R.id.layout_main))
       .check(matches(isClosed(Gravity.START)))
       .perform(DrawerActions.open(Gravity.START))
     onView(withId(R.id.navigation_drawer)).perform(NavigationViewActions.navigateTo(R.id.saved_presets))
-    sleep(1000L) // tests fail complaining drawer is open. let it close..? (doesn't happen always! :/)
 
     onView(withId(R.id.layout_main))
       .check(matches(isClosed(Gravity.START)))
       .perform(DrawerActions.open(Gravity.START))
     onView(withId(R.id.navigation_drawer)).perform(NavigationViewActions.navigateTo(R.id.about))
 
+    onView(withId(R.id.layout_main)).check(matches(isClosed(Gravity.START)))
+    IdlingRegistry.getInstance().unregister(drawerIdlingResource)
+
     activityScenario.onActivity {
       it.onBackPressed()
-    }
-
-    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    activityScenario.onActivity {
       assertEquals(
         PresetFragment::class.java.simpleName,
         it.supportFragmentManager
@@ -195,10 +214,6 @@ class MainActivityTest {
       )
 
       it.onBackPressed()
-    }
-
-    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    activityScenario.onActivity {
       assertEquals(
         SoundLibraryFragment::class.java.simpleName,
         it.supportFragmentManager

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/DialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/DialogFragmentTest.kt
@@ -153,11 +153,12 @@ class DialogFragmentTest {
       .targetContext
       .resources
       .getStringArray(R.array.app_themes)
-
     activityScenario.onActivity {
       dialogFragment.show(it.supportFragmentManager) {
+        dialogIdlingResource.increment()
         singleChoiceItems(R.array.app_themes, currentChoice = selectedItem) { choice ->
           selectedItem = choice
+          dialogIdlingResource.decrement()
         }
       }
     }
@@ -170,6 +171,8 @@ class DialogFragmentTest {
     onView(allOf(isDescendantOfA(withId(android.R.id.list)), withText(items[1])))
       .perform(click())
 
+    IdlingRegistry.getInstance().register(dialogIdlingResource)
+    onView(withId(android.R.id.list)).check(doesNotExist())
     assertEquals(1, selectedItem)
   }
 }

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/MainActivity.kt
@@ -1,9 +1,12 @@
 package com.github.ashutoshgngwr.noice
 
+import android.app.ActivityManager
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
@@ -84,7 +87,19 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
   override fun onResume() {
     super.onResume()
     // start the media player service
-    startService(Intent(this, MediaPlayerService::class.java))
+    // workaround for Android 9+. See https://github.com/ashutoshgngwr/noice/issues/179
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      (getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager).also {
+        val importance = it.runningAppProcesses.firstOrNull()?.importance
+          ?: ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE
+
+        if (importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
+          startService(Intent(this, MediaPlayerService::class.java))
+        }
+      }
+    } else {
+      startService(Intent(this, MediaPlayerService::class.java))
+    }
   }
 
   override fun onOptionsItemSelected(item: MenuItem): Boolean {


### PR DESCRIPTION
### Changes

- Add a workaround as suggested [here](https://issuetracker.google.com/issues/110237673#comment9).

### Testing
- [x] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Fixes #179
