### PR TITLE
Fixes incorrect time period offsets for saved presets

### DIFF
--- a/app/src/test/java/com/github/ashutoshgngwr/noice/sound/PresetTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/sound/PresetTest.kt
@@ -2,6 +2,7 @@ package com.github.ashutoshgngwr.noice.sound
 
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
+import com.github.ashutoshgngwr.noice.sound.player.Player
 import io.mockk.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -82,7 +83,8 @@ class PresetTest {
     assertEquals("test", presets[0].name)
     assertEquals(1, presets[0].playerStates.size)
     assertEquals("test-1", presets[0].playerStates[0].soundKey)
-    assertEquals(30, presets[0].playerStates[0].timePeriod)
+    // returned time period should have correct offset
+    assertEquals(Player.MIN_TIME_PERIOD + 30, presets[0].playerStates[0].timePeriod)
     assertEquals(15, presets[0].playerStates[0].volume)
   }
 
@@ -114,7 +116,7 @@ class PresetTest {
         every { playerStates } returns arrayOf(mockk {
           every { soundKey } returns "test-1"
           every { volume } returns 15
-          every { timePeriod } returns 30
+          every { timePeriod } returns Player.MIN_TIME_PERIOD + 30
         })
       }
     ))
@@ -169,7 +171,7 @@ class PresetTest {
       every { playerStates } returns arrayOf(mockk {
         every { soundKey } returns "test-1"
         every { volume } returns 15
-        every { timePeriod } returns 30
+        every { timePeriod } returns Player.MIN_TIME_PERIOD + 30
       })
     })
 


### PR DESCRIPTION
### Changes
fix for offset corrections introduced in the following commits
1. https://github.com/ashutoshgngwr/noice/commit/b449ef643227b65685b71f7780a814c606e6abad
2. https://github.com/ashutoshgngwr/noice/commit/8ef502debd84aeadadaa665acd37c3cee592f521
3. https://github.com/ashutoshgngwr/noice/commit/11eb63ee22f3a03eca982cbd308f06ec164ab300#diff-db23b0e75244cdeb8ead7184bb06cb7cR15-R71


### Testing
- [x] Tested on a physical device
- [x] Added or modified unit test cases

### Others
- Fixes _N/A_
- Connects #193 
