### PR TITLE
Fixes playback not resuming on gaining audio focus after a transient loss

### DIFF
--- a/app/src/test/java/com/github/ashutoshgngwr/noice/sound/player/PlayerManagerTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/sound/player/PlayerManagerTest.kt
@@ -154,17 +154,12 @@ class PlayerManagerTest {
 
   @Test
   fun testPausePlayback() {
-    mockkStatic(AudioManagerCompat::class)
     playerManager.pause()
 
     assertEquals(PlayerManager.State.PAUSED, playerManager.state)
     assertEquals(PlaybackStateCompat.STATE_PAUSED, ShadowMediaSessionCompat.getLastPlaybackState())
     assertEquals(1, playerManager.players.size)
-    verify(exactly = 1) {
-      players.getValue("test").pause()
-      // should abandon audio focus
-      AudioManagerCompat.abandonAudioFocusRequest(any(), any())
-    }
+    verify(exactly = 1) { players.getValue("test").pause() }
   }
 
   @Test


### PR DESCRIPTION
### Changes
- Remove abandon audio focus call when playback is paused
- Add a method to stop playback with a delayed stop on indefinite paused
- Fix Handler#removeCallbacks calls (wasn't working with Kotlin function references)

### Testing
- [x] Tested on a physical device
- [x] Added or modified unit test cases

### Others
- Fixes #219