### PR TITLE
Update in Brazilian Portuguese translations for Fastlane Metadata

### DIFF
--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/AboutFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/AboutFragment.kt
@@ -91,6 +91,10 @@ class AboutFragment : Fragment() {
         R.string.credits__translation_pt_br_0__url
       ),
       arrayOf(
+        R.string.credits__translation_pt_br_1,
+        R.string.credits__translation_pt_br_1__url
+      ),
+      arrayOf(
         R.string.credits__translation_es_es_0,
         R.string.credits__translation_es_es_0__url
       ),

--- a/app/src/main/res/values/dont_translate.xml
+++ b/app/src/main/res/values/dont_translate.xml
@@ -124,6 +124,8 @@
   <string name="credits__translation_fr_fr_1__url" translatable="false">https://github.com/Mickael-Martin</string>
   <string name="credits__translation_pt_br_0" translatable="false">Portuguese (Brazil) translation by Vinny</string>
   <string name="credits__translation_pt_br_0__url" translatable="false">https://github.com/CebolaBros64</string>
+  <string name="credits__translation_pt_br_1" translatable="false">Portuguese (Brazil) translation by Lucas Teixeira</string>
+  <string name="credits__translation_pt_br_1__url" translatable="false">https://github.com/lucastsantos</string>
   <string name="credits__translation_sv_0" translatable="false">Swedish translation by Ricky Lindén</string>
   <string name="credits__translation_sv_0__url" translatable="false">https://github.com/sherpashrapnel</string>
   <string name="credits__translation_sq_al_0" translatable="false">Albanian translation by 3rg1s</string>

--- a/fastlane/metadata/android/pt-BR/full_description.txt
+++ b/fastlane/metadata/android/pt-BR/full_description.txt
@@ -5,20 +5,30 @@ Noice é um aplicativo que lhe permite simular seu próprio "ambiente sonoro" us
 <b>Funções</b>
 - 35 sons disponíveis
 - Google Cast (Chromecast) ativado [apenas na versão Play Store]
-- Misture e ajuste sons a gosto
+- Temporizador
 - Despertador
+- Faça um mix personalizado
 - Salve seus ajustes para uso futuro
-- Timer para uso no sono
 - Funciona em conjunto com qualquer aplicativo de música
-- Ajuste o volume de cada som indivídualmente
+- Ajuste o volume de cada som individualmente
 - Não precisa de internet
-- Disponíveis temas claro e escuro
+- Variações de tema claro e escuro
 
-<b>Sons disponíveis</b>
-- Sons de natureza (pássaros, fogueira, beira-mar...)
-- Sons do clima (chuva, trovões, vento...)
-- Sons de lugares (escritório, trem, cafeteria, avião...)
-- Ruído em cores (ruído branco, rosa, vermelho)
+<b>Bibliotecas de ruídos</b>
+- Vida (pássaros, grilos, lobo, batimento cardíaco humano, etc.)
+- Floresta (fogueira, noite, vento, palmeiras, etc.)
+- Monção (chuva, trovões)
+- Teleportação (cafeteria, biblioteca, escritório, beira-mar, margem do rio, etc.)
+- Veículo (trem em movimento, avião em voo, navio rangendo, carro elétrico, etc.)
+- Ruído bruto (branco, rosa, vermelho)
+
+<b>Permissões</b>
+- <b>impedir modo de inatividade do telefone</b>: para manter a CPU do dispositivo ativa durante a reprodução
+- <b>executar serviço em primeiro plano</b>: para executar o processo do player (diferente da IU)
+- <b>executar na inicialização</b>: para garantir que os despertadores persistam durante reinicializações
+- <b>acesso total à rede</b>: para habilitar o Chromecast e contribuições financeiras
+- <b>ver conexões de rede</b>: adicionado por uma dependência, atualmente não está em uso
+- <b>Sistema de faturamento do Google Play</b>: para permitir contribuições financeiras para apoiar o desenvolvimento
 
 Noice é um aplicativo livre e de código aberto.
 https://github.com/ashutoshgngwr/noice


### PR DESCRIPTION
### Changes
Changed the fastlane metadata to match the current english metadata

### Testing
- [X] Tested on a physical device
- [ ] Added or modified unit test cases

### Others
- Connects #200 
- Connects https://github.com/ashutoshgngwr/noice/pull/381#issuecomment-711047176
