### PR TITLE
Use alarm stream to play presets in Wake-up Timers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,6 +113,7 @@ dependencies {
   implementation 'com.google.android.material:material:1.4.0'
   implementation 'com.google.code.gson:gson:2.8.7'
   implementation 'com.hopenlib.library:flextools:1.0.1'
+  implementation 'com.ncorti:slidetoact:0.9.0'
   implementation 'io.noties.markwon:core:4.6.2'
   implementation 'org.greenrobot:eventbus:3.1.1'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/EspressoX.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/EspressoX.kt
@@ -2,7 +2,6 @@ package com.github.ashutoshgngwr.noice
 
 import android.content.Intent
 import android.view.View
-import android.widget.CompoundButton
 import android.widget.TimePicker
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
@@ -14,7 +13,6 @@ import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.MotionEvents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
-import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.espresso.util.TreeIterables
 import com.github.ashutoshgngwr.noice.widget.DurationPicker
@@ -80,21 +78,6 @@ object EspressoX {
     }
   }
 
-  /**
-   * [withSliderValue] matches a [Slider] with the provided [expectedValue].
-   */
-  fun withSliderValue(expectedValue: Float): Matcher<View> {
-    return object : BoundedMatcher<View, Slider>(Slider::class.java) {
-      override fun describeTo(description: Description) {
-        description.appendText("Slider with value $expectedValue")
-      }
-
-      override fun matchesSafely(slider: Slider): Boolean {
-        return expectedValue == slider.value
-      }
-    }
-  }
-
   private fun searchForView(viewMatcher: Matcher<View>): ViewAction {
     return object : ViewAction {
       override fun getConstraints() = isRoot()
@@ -129,7 +112,8 @@ object EspressoX {
   ): ViewInteraction {
     require(retries > 0 && wait > 0)
     val viewMatcher = allOf(*viewMatchers)
-    for (i in 0 until retries) {
+    var i = 0
+    while(i++ < retries) {
       try {
         onView(isRoot()).perform(searchForView(viewMatcher))
         break
@@ -190,22 +174,6 @@ object EspressoX {
       override fun describeTo(description: Description?) = Unit
       override fun matchesSafely(item: View?): Boolean {
         return item is TimePicker && item.is24HourView
-      }
-    }
-  }
-
-  /**
-   * [setChecked] returns a [ViewAction] to set the checked state of a [CompoundButton].
-   */
-  fun setChecked(checked: Boolean): ViewAction {
-    return object : ViewAction {
-      override fun getDescription() = "check/uncheck compound buttons"
-      override fun getConstraints() = instanceOf<View>(CompoundButton::class.java)
-
-      override fun perform(uiController: UiController, view: View) {
-        if (view is CompoundButton) {
-          view.isChecked = checked
-        }
       }
     }
   }

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/EspressoX.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/EspressoX.kt
@@ -5,16 +5,12 @@ import android.view.View
 import android.widget.TimePicker
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
-import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.MotionEvents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.matcher.ViewMatchers.*
-import androidx.test.espresso.util.TreeIterables
 import com.github.ashutoshgngwr.noice.widget.DurationPicker
 import com.google.android.material.slider.Slider
 import com.google.android.material.textfield.TextInputLayout
@@ -22,6 +18,7 @@ import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.*
 import org.hamcrest.TypeSafeMatcher
+import kotlin.reflect.KClass
 
 /**
  * [EspressoX] contains the custom extended util implementations for Espresso.
@@ -76,57 +73,6 @@ object EspressoX {
         MotionEvents.sendUp(uiController, down, endCoordinates)
       }
     }
-  }
-
-  private fun searchForView(viewMatcher: Matcher<View>): ViewAction {
-    return object : ViewAction {
-      override fun getConstraints() = isRoot()
-      override fun getDescription() = "search for view with $viewMatcher in the root view"
-
-      override fun perform(uiController: UiController, view: View) {
-        TreeIterables.breadthFirstViewTraversal(view).forEach {
-          if (viewMatcher.matches(it)) {
-            return
-          }
-        }
-
-        throw NoMatchingViewException.Builder()
-          .withRootView(view)
-          .withViewMatcher(viewMatcher)
-          .build()
-      }
-    }
-  }
-
-  /**
-   * [waitForView] tries to find a view with given [viewMatchers]. If found, it returns the
-   * [ViewInteraction] for given [viewMatchers]. If not found, it waits for given [wait]
-   * before attempting to find the view again. It reties for given number of [retries].
-   *
-   * Adaptation of the [StackOverflow post by manbradcalf](https://stackoverflow.com/a/56499223/2410641)
-   */
-  fun waitForView(
-    vararg viewMatchers: Matcher<View>,
-    retries: Int = 5,
-    wait: Long = 1000L,
-  ): ViewInteraction {
-    require(retries > 0 && wait > 0)
-    val viewMatcher = allOf(*viewMatchers)
-    var i = 0
-    while(i++ < retries) {
-      try {
-        onView(isRoot()).perform(searchForView(viewMatcher))
-        break
-      } catch (e: NoMatchingViewException) {
-        if (i == retries) {
-          throw e
-        }
-
-        Thread.sleep(wait)
-      }
-    }
-
-    return onView(viewMatcher)
   }
 
   /**
@@ -196,6 +142,33 @@ object EspressoX {
       override fun getDescription() = "no-op"
       override fun getConstraints() = any(View::class.java)
       override fun perform(uiController: UiController, view: View) = Unit
+    }
+  }
+
+  /**
+   * Retries the given [block] by catching the [expectedErrors] until all [retries] are exhausted.
+   * It waits for a defined [wait] period between each retry.
+   */
+  inline fun retryWithWaitOnError(
+    vararg expectedErrors: KClass<out Throwable>,
+    retries: Int = 15,
+    wait: Long = 500,
+    block: () -> Unit,
+  ) {
+    require(retries > 0 && wait > 0)
+
+    var i = 0
+    while (i++ < retries) {
+      try {
+        block.invoke()
+        break
+      } catch (e: Throwable) {
+        if (!expectedErrors.any { it.isInstance(e) } || i == retries) {
+          throw e
+        }
+
+        Thread.sleep(wait)
+      }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/RetryTestRule.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/RetryTestRule.kt
@@ -14,7 +14,7 @@ class RetryTestRule(private val retryCount: Int = 5) : TestRule {
           break
         } catch (t: Throwable) {
           if (i == retryCount) {
-            throw Exception("Test failed after $retryCount retries", t)
+            throw t
           }
         }
       }

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/activity/AlarmRingerActivityTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/activity/AlarmRingerActivityTest.kt
@@ -1,0 +1,75 @@
+package com.github.ashutoshgngwr.noice.activity
+
+import android.content.Intent
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.lifecycle.Lifecycle
+import androidx.media.AudioAttributesCompat
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.swipeRight
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.ashutoshgngwr.noice.R
+import com.github.ashutoshgngwr.noice.playback.PlaybackController
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AlarmRingerActivityTest {
+
+  @Before
+  fun setup() {
+    mockkObject(PlaybackController)
+    every { PlaybackController.setAudioUsage(any(), any()) } returns Unit
+    every { PlaybackController.pause(any()) } returns Unit
+    every { PlaybackController.playPreset(any(), any()) } returns Unit
+  }
+
+  @After
+  fun teardown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun testWithoutPresetID() {
+    val scenario = ActivityScenario.launch(AlarmRingerActivity::class.java)
+    assertEquals(Lifecycle.State.DESTROYED, scenario.state)
+  }
+
+  @Test
+  fun testWithPresetID() {
+    val presetID = "test-preset-id"
+
+    // cannot launch Activity using `ActivityScenario.launch(Intent)` method. For whatever reasons,
+    // it increases the startup time for all subsequent `ActivityScenario.launch(Class)`s from
+    // other classes.
+    FragmentScenario.launch(Fragment::class.java).onFragment {
+      it.startActivity(
+        Intent(it.requireContext(), AlarmRingerActivity::class.java)
+          .putExtra(AlarmRingerActivity.EXTRA_PRESET_ID, presetID)
+      )
+    }
+
+    verify(exactly = 1, timeout = 10000L) {
+      PlaybackController.setAudioUsage(any(), AudioAttributesCompat.USAGE_ALARM)
+      PlaybackController.playPreset(any(), presetID)
+    }
+
+    clearMocks(PlaybackController)
+    onView(withId(R.id.dismiss_slider)).perform(swipeRight())
+
+    verify(exactly = 1, timeout = 10000L) {
+      PlaybackController.setAudioUsage(any(), AudioAttributesCompat.USAGE_MEDIA)
+      PlaybackController.pause(any())
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/activity/AppIntroActivityTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/activity/AppIntroActivityTest.kt
@@ -1,6 +1,7 @@
 package com.github.ashutoshgngwr.noice.activity
 
 import androidx.core.content.edit
+import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -8,6 +9,7 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.ashutoshgngwr.noice.EspressoX
 import com.github.ashutoshgngwr.noice.RetryTestRule
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -33,20 +35,18 @@ class AppIntroActivityTest {
 
   @After
   fun teardown() {
-    activityScenario.close()
     PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
-      .edit(commit = true) {
-        clear()
-      }
+      .edit { clear() }
   }
 
   @Test
   fun testOnSkipPressed() {
     activityScenario.onActivity {
       it.onSkipPressed(null)
+    }
 
-      // should destroy the activity
-      assertTrue(it.isFinishing || it.isDestroyed)
+    EspressoX.retryWithWaitOnError(AssertionError::class) {
+      assertEquals(Lifecycle.State.DESTROYED, activityScenario.state)
     }
 
     // should update the preferences
@@ -60,9 +60,10 @@ class AppIntroActivityTest {
   fun testOnDonePressed() {
     activityScenario.onActivity {
       it.onDonePressed(null)
+    }
 
-      // should destroy the activity
-      assertTrue(it.isFinishing || it.isDestroyed)
+    EspressoX.retryWithWaitOnError(AssertionError::class) {
+      assertEquals(Lifecycle.State.DESTROYED, activityScenario.state)
     }
 
     // should update the preferences
@@ -94,9 +95,7 @@ class AppIntroActivityTest {
       // when user has already seen the activity once, i.e., if the preference is present in the
       // storage, maybeStart shouldn't start the activity.
       PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
-        .edit(commit = true) {
-          putBoolean(AppIntroActivity.PREF_HAS_USER_SEEN_APP_INTRO, true)
-        }
+        .edit { putBoolean(AppIntroActivity.PREF_HAS_USER_SEEN_APP_INTRO, true) }
 
       activityScenario.onActivity {
         AppIntroActivity.maybeStart(it)

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/activity/ShortcutHandlerActivityTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/activity/ShortcutHandlerActivityTest.kt
@@ -60,7 +60,7 @@ class ShortcutHandlerActivityTest {
         Intent(ApplicationProvider.getApplicationContext(), ShortcutHandlerActivity::class.java)
           .putExtra(ShortcutHandlerActivity.EXTRA_SHORTCUT_ID, presetIDExpectations[i])
           .putExtra(ShortcutHandlerActivity.EXTRA_PRESET_ID, presetIDExpectations[i])
-          .also { ActivityScenario.launch<ShortcutHandlerActivity>(it).close() }
+          .also { ActivityScenario.launch<ShortcutHandlerActivity>(it) }
 
         Intents.intended(
           allOf(

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/DialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/DialogFragmentTest.kt
@@ -60,7 +60,7 @@ class DialogFragmentTest {
       }
     }
 
-    EspressoX.waitForView(withId(R.id.positive), withText(R.string.app_name))
+    onView(allOf(withId(R.id.positive), withText(R.string.app_name)))
       .perform(click())
 
     onView(withId(R.id.positive)).check(doesNotExist())
@@ -74,7 +74,7 @@ class DialogFragmentTest {
       }
     }
 
-    EspressoX.waitForView(withId(R.id.negative), withText(R.string.app_name))
+    onView(allOf(withId(R.id.negative), withText(R.string.app_name)))
       .perform(click())
 
     onView(withId(R.id.negative)).check(doesNotExist())
@@ -88,7 +88,7 @@ class DialogFragmentTest {
       }
     }
 
-    EspressoX.waitForView(withId(R.id.neutral), withText(android.R.string.copy))
+    onView(allOf(withId(R.id.neutral), withText(android.R.string.copy)))
       .perform(click())
 
     onView(withId(R.id.neutral)).check(doesNotExist())
@@ -155,7 +155,8 @@ class DialogFragmentTest {
     }
 
     items.forEach {
-      EspressoX.waitForView(isDescendantOfA(withId(android.R.id.list)), withText(it), isDisplayed())
+      onView(allOf(isDescendantOfA(withId(android.R.id.list)), withText(it)))
+        .check(matches(isDisplayed()))
     }
 
     onView(allOf(isDescendantOfA(withId(android.R.id.list)), withText(items[1])))
@@ -185,7 +186,8 @@ class DialogFragmentTest {
       }
     }
 
-    EspressoX.waitForView(withId(id)).check(matches(isDisplayed()))
+    onView(withId(id))
+      .check(matches(isDisplayed()))
       .perform(EspressoX.slide(expectedValue))
 
     onView(withId(R.id.positive)).perform(click())

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/LibraryFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/LibraryFragmentTest.kt
@@ -276,10 +276,7 @@ class LibraryFragmentTest {
 
     onView(withId(R.id.positive)).perform(click())
     verify(exactly = 1) { requireNotNull(mockPlayers["birds"]).setVolume(6) }
-    EspressoX.waitForView(
-      withId(R.id.save_preset_button),
-      withEffectiveVisibility(Visibility.VISIBLE)
-    )
+    onView(allOf(withId(R.id.save_preset_button), withEffectiveVisibility(Visibility.VISIBLE)))
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/SettingsFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/SettingsFragmentTest.kt
@@ -13,12 +13,12 @@ import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.ashutoshgngwr.noice.EspressoX
 import com.github.ashutoshgngwr.noice.R
 import com.github.ashutoshgngwr.noice.RetryTestRule
 import com.github.ashutoshgngwr.noice.repository.SettingsRepository
 import io.mockk.mockkStatic
 import io.mockk.verify
+import org.hamcrest.Matchers.allOf
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -69,7 +69,7 @@ class SettingsFragmentTest {
         )
       )
 
-    EspressoX.waitForView(withId(R.id.positive), withText(R.string.okay))
+    onView(allOf(withId(R.id.positive), withText(R.string.okay)))
       .perform(click())
 
     verify(exactly = 1) { ShortcutManagerCompat.removeAllDynamicShortcuts(any()) }

--- a/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/WakeUpTimerFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/ashutoshgngwr/noice/fragment/WakeUpTimerFragmentTest.kt
@@ -140,7 +140,7 @@ class WakeUpTimerFragmentTest {
       .check(matches(withText(R.string.select_preset)))
       .perform(click())
 
-    EspressoX.waitForView(withText(R.string.preset_info__description))
+    onView(withText(R.string.preset_info__description))
       .check(matches(isDisplayed()))
   }
 
@@ -164,7 +164,7 @@ class WakeUpTimerFragmentTest {
     onView(withId(R.id.select_preset_button))
       .perform(click())
 
-    EspressoX.waitForView(withId(android.R.id.list))
+    onView(withId(android.R.id.list))
       .check(matches(withChild(withText("test-1"))))
       .check(matches(withChild(withText("test-2"))))
 

--- a/app/src/androidTestPlaystore/java/com/github/ashutoshgngwr/noice/GenerateScreenshots.kt
+++ b/app/src/androidTestPlaystore/java/com/github/ashutoshgngwr/noice/GenerateScreenshots.kt
@@ -67,7 +67,7 @@ class GenerateScreenshots {
 
       // prevent app intro and data consent from showing up
       PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
-        .edit(commit = true) {
+        .edit {
           clear() // clear any existing preferences.
           putBoolean(AppIntroActivity.PREF_HAS_USER_SEEN_APP_INTRO, true)
           putBoolean(MainActivity.PREF_HAS_SEEN_DATA_COLLECTION_CONSENT, true)
@@ -196,7 +196,7 @@ class GenerateScreenshots {
       )
     )
 
-    EspressoX.waitForView(withId(R.id.volume_slider))
+    onView(withId(R.id.volume_slider))
       .perform(EspressoX.slide(Player.MAX_VOLUME.toFloat() - Player.DEFAULT_VOLUME))
 
     onView(withId(R.id.positive))
@@ -218,7 +218,7 @@ class GenerateScreenshots {
       )
     )
 
-    EspressoX.waitForView(withId(R.id.volume_slider))
+    onView(withId(R.id.volume_slider))
       .perform(EspressoX.slide(Player.MAX_VOLUME.toFloat()))
 
     onView(withId(R.id.positive))
@@ -231,7 +231,7 @@ class GenerateScreenshots {
       )
     )
 
-    EspressoX.waitForView(withId(R.id.time_period_slider))
+    onView(withId(R.id.time_period_slider))
       .perform(EspressoX.slide(Player.MAX_TIME_PERIOD.toFloat() - 300))
 
     onView(withId(R.id.positive))
@@ -247,10 +247,10 @@ class GenerateScreenshots {
       .check(matches(DrawerMatchers.isClosed(Gravity.START)))
       .perform(DrawerActions.open(Gravity.START))
 
-    EspressoX.waitForView(withId(R.id.navigation_drawer))
+    onView(withId(R.id.navigation_drawer))
       .perform(NavigationViewActions.navigateTo(R.id.saved_presets))
 
-    EspressoX.waitForView(withId(R.id.list))
+    onView(withId(R.id.list))
       .perform(
         actionOnItemAtPosition<SavedPresetsFragment.ViewHolder>(
           1, EspressoX.clickInItem(R.id.play_button)
@@ -274,7 +274,7 @@ class GenerateScreenshots {
       .check(matches(DrawerMatchers.isClosed(Gravity.START)))
       .perform(DrawerActions.open(Gravity.START))
 
-    EspressoX.waitForView(withId(R.id.navigation_drawer))
+    onView(withId(R.id.navigation_drawer))
       .perform(NavigationViewActions.navigateTo(R.id.sleep_timer))
 
     onView(withId(R.id.duration_picker)).perform(
@@ -294,13 +294,13 @@ class GenerateScreenshots {
       .check(matches(DrawerMatchers.isClosed(Gravity.START)))
       .perform(DrawerActions.open(Gravity.START))
 
-    EspressoX.waitForView(withId(R.id.navigation_drawer))
+    onView(withId(R.id.navigation_drawer))
       .perform(NavigationViewActions.navigateTo(R.id.wake_up_timer))
 
-    EspressoX.waitForView(withId(R.id.select_preset_button))
+    onView(withId(R.id.select_preset_button))
       .perform(scrollTo(), click())
 
-    EspressoX.waitForView(withText("Airplane"))
+    onView(withText("Airplane"))
       .perform(scrollTo(), click())
 
     onView(withId(R.id.time_picker))
@@ -322,10 +322,10 @@ class GenerateScreenshots {
       .check(matches(DrawerMatchers.isClosed(Gravity.START)))
       .perform(DrawerActions.open(Gravity.START))
 
-    EspressoX.waitForView(withId(R.id.navigation_drawer))
+    onView(withId(R.id.navigation_drawer))
       .perform(NavigationViewActions.navigateTo(R.id.about))
 
-    EspressoX.waitForView(withText(R.string.app_description))
+    onView(withText(R.string.app_description))
     Thread.sleep(SLEEP_PERIOD_BEFORE_SCREENGRAB)
     Screengrab.screenshot("5")
   }
@@ -336,7 +336,7 @@ class GenerateScreenshots {
       .check(matches(DrawerMatchers.isClosed(Gravity.START)))
       .perform(DrawerActions.open(Gravity.START))
 
-    EspressoX.waitForView(withId(R.id.layout_main), DrawerMatchers.isOpen())
+    onView(withId(R.id.layout_main)).check(matches(DrawerMatchers.isOpen()))
     Thread.sleep(SLEEP_PERIOD_BEFORE_SCREENGRAB)
     Screengrab.screenshot("6")
   }
@@ -347,10 +347,10 @@ class GenerateScreenshots {
       .check(matches(DrawerMatchers.isClosed(Gravity.START)))
       .perform(DrawerActions.open(Gravity.START))
 
-    EspressoX.waitForView(withId(R.id.navigation_drawer))
+    onView(withId(R.id.navigation_drawer))
       .perform(NavigationViewActions.navigateTo(R.id.settings))
 
-    EspressoX.waitForView(withId(R.id.navigation_drawer), DrawerMatchers.isClosed())
+    onView(withId(R.id.navigation_drawer)).check(matches(DrawerMatchers.isClosed()))
     Thread.sleep(SLEEP_PERIOD_BEFORE_SCREENGRAB)
     Screengrab.screenshot("7")
   }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,6 @@
 
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-
   <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
 
   <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,7 +64,6 @@
 
       </intent-filter>
 
-
     </activity>
 
     <activity
@@ -73,8 +72,13 @@
 
     <activity
       android:name=".activity.ShortcutHandlerActivity"
-      android:exported="true"
-      android:excludeFromRecents="true" />
+      android:excludeFromRecents="true"
+      android:exported="true" />
+
+    <activity
+      android:name=".activity.AlarmRingerActivity"
+      android:excludeFromRecents="true"
+      android:launchMode="singleInstance" />
 
     <service android:name=".MediaPlayerService" />
 

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/MediaPlayerService.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/MediaPlayerService.kt
@@ -7,9 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
-import android.os.Handler
 import android.os.IBinder
-import android.os.Looper
 import android.os.PowerManager
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
@@ -51,8 +49,6 @@ class MediaPlayerService : Service() {
   private lateinit var playerManager: PlayerManager
   private lateinit var presetRepository: PresetRepository
   private lateinit var settingsRepository: SettingsRepository
-
-  private val handler = Handler(Looper.getMainLooper())
 
   private val becomingNoisyReceiver = object : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
@@ -134,7 +130,7 @@ class MediaPlayerService : Service() {
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-    intent?.also { PlaybackController.handleServiceIntent(this, playerManager, it, handler) }
+    intent?.also { PlaybackController.handleServiceIntent(this, playerManager, it) }
     return START_STICKY
   }
 
@@ -142,7 +138,7 @@ class MediaPlayerService : Service() {
     unregisterReceiver(becomingNoisyReceiver)
     playerManager.cleanup()
     mediaSession.release()
-    PlaybackController.clearAutoStopCallback(handler)
+    PlaybackController.clearAutoStopCallback()
     wakeLock.release()
     super.onDestroy()
   }

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/WakeUpTimerManager.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/WakeUpTimerManager.kt
@@ -20,12 +20,7 @@ object WakeUpTimerManager {
   /**
    * [Timer] declares fields necessary to schedule a Wake-up timer.
    */
-  data class Timer(
-    @Expose var presetID: String,
-    @Expose var atMillis: Long,
-    @Expose var shouldUpdateMediaVolume: Boolean,
-    @Expose var mediaVolume: Int
-  )
+  data class Timer(@Expose var presetID: String, @Expose var atMillis: Long)
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   const val PREF_WAKE_UP_TIMER = "wake_up_timer"
@@ -67,12 +62,7 @@ object WakeUpTimerManager {
     withAlarmManager(context) {
       it.setAlarmClock(
         AlarmManager.AlarmClockInfo(timer.atMillis, getPendingIntentForActivity(context)),
-        PlaybackController.buildAlarmPendingIntent(
-          context,
-          timer.presetID,
-          timer.shouldUpdateMediaVolume,
-          timer.mediaVolume
-        )
+        PlaybackController.buildAlarmPendingIntent(context, timer.presetID)
       )
     }
   }
@@ -87,7 +77,7 @@ object WakeUpTimerManager {
 
     withAlarmManager(context) {
       // don't need concrete timer value for cancelling the alarm.
-      it.cancel(PlaybackController.buildAlarmPendingIntent(context, null, false, -1))
+      it.cancel(PlaybackController.buildAlarmPendingIntent(context, null))
     }
   }
 

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/WakeUpTimerManager.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/WakeUpTimerManager.kt
@@ -9,8 +9,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.core.content.getSystemService
 import androidx.preference.PreferenceManager
+import com.github.ashutoshgngwr.noice.activity.AlarmRingerActivity
 import com.github.ashutoshgngwr.noice.activity.MainActivity
-import com.github.ashutoshgngwr.noice.playback.PlaybackController
 import com.github.ashutoshgngwr.noice.repository.PresetRepository
 import com.google.gson.GsonBuilder
 import com.google.gson.annotations.Expose
@@ -62,7 +62,7 @@ object WakeUpTimerManager {
     withAlarmManager(context) {
       it.setAlarmClock(
         AlarmManager.AlarmClockInfo(timer.atMillis, getPendingIntentForActivity(context)),
-        PlaybackController.buildAlarmPendingIntent(context, timer.presetID)
+        AlarmRingerActivity.getPendingIntent(context, timer.presetID)
       )
     }
   }
@@ -77,7 +77,7 @@ object WakeUpTimerManager {
 
     withAlarmManager(context) {
       // don't need concrete timer value for cancelling the alarm.
-      it.cancel(PlaybackController.buildAlarmPendingIntent(context, null))
+      it.cancel(AlarmRingerActivity.getPendingIntent(context, null))
     }
   }
 

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/activity/AlarmRingerActivity.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/activity/AlarmRingerActivity.kt
@@ -1,0 +1,129 @@
+package com.github.ashutoshgngwr.noice.activity
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.view.Window
+import android.view.WindowManager
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.content.ContextCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.media.AudioAttributesCompat
+import com.github.ashutoshgngwr.noice.MediaPlayerService
+import com.github.ashutoshgngwr.noice.databinding.AlarmRingerActivityBinding
+import com.github.ashutoshgngwr.noice.playback.PlaybackController
+import com.github.ashutoshgngwr.noice.repository.SettingsRepository
+import com.ncorti.slidetoact.SlideToActView
+
+class AlarmRingerActivity : AppCompatActivity(), SlideToActView.OnSlideCompleteListener {
+
+  companion object {
+    @VisibleForTesting
+    internal const val EXTRA_PRESET_ID = "preset_id"
+
+    private const val RC_ALARM = 0x39
+
+    fun getPendingIntent(context: Context, presetID: String?): PendingIntent {
+      return Intent(context, AlarmRingerActivity::class.java)
+        .putExtra(EXTRA_PRESET_ID, presetID)
+        .let { PendingIntent.getActivity(context, RC_ALARM, it, PendingIntent.FLAG_UPDATE_CURRENT) }
+    }
+  }
+
+  private lateinit var binding: AlarmRingerActivityBinding
+  private lateinit var settingsRepository: SettingsRepository
+
+  private var shouldPausePlaybackOnStop = false
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    settingsRepository = SettingsRepository.newInstance(this)
+    AppCompatDelegate.setDefaultNightMode(settingsRepository.getAppThemeAsNightMode())
+    super.onCreate(savedInstanceState)
+
+    requestWindowFeature(Window.FEATURE_NO_TITLE);
+    binding = AlarmRingerActivityBinding.inflate(layoutInflater)
+    binding.dismissSlider.onSlideCompleteListener = this
+    setContentView(binding.root)
+    showWhenLocked()
+    enableImmersiveMode()
+
+    handleNewIntent()
+  }
+
+  override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    handleNewIntent()
+  }
+
+  override fun onStop() {
+    super.onStop()
+
+    if (shouldPausePlaybackOnStop) {
+      PlaybackController.pause(this)
+      PlaybackController.setAudioUsage(this, AudioAttributesCompat.USAGE_MEDIA)
+      shouldPausePlaybackOnStop = false
+    }
+  }
+
+  override fun onBackPressed() = Unit
+
+  override fun onSlideComplete(view: SlideToActView) {
+    finish()
+  }
+
+  private fun enableImmersiveMode() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      window.attributes.layoutInDisplayCutoutMode =
+        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+    }
+
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    WindowCompat.getInsetsController(window, binding.root)?.apply {
+      systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+      hide(WindowInsetsCompat.Type.systemBars())
+    }
+  }
+
+  private fun showWhenLocked() {
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+      setShowWhenLocked(true)
+      setTurnScreenOn(true)
+    } else {
+      @Suppress("Deprecation")
+      window.addFlags(
+        WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+          WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+      )
+    }
+  }
+
+
+  private fun handleNewIntent() {
+    val presetID = intent.getStringExtra(EXTRA_PRESET_ID)
+    if (presetID == null) {
+      finish()
+      return
+    }
+
+    // Since activity takes a moment to actually show up, invoking `startService` from `onCreate` or
+    // `onResume` fails with `java.lang.IllegalStateException: Not allowed to start service Intent:
+    // app is in background` on recent Android version (O+). `PlaybackController` can not call
+    // `startForegroundService` since it doesn't know if an action will bring `MediaPlayerService`
+    // to foreground. To prevent `PlaybackController` from causing this error by invoking
+    // `startService`, we need to manually start `MediaPlayerService` in the foreground since we can
+    // be certain that playPreset action will bring it to foreground before Android System kills it.
+    ContextCompat.startForegroundService(this, Intent(this, MediaPlayerService::class.java))
+
+    PlaybackController.setAudioUsage(this, AudioAttributesCompat.USAGE_ALARM)
+    PlaybackController.playPreset(this, presetID)
+    shouldPausePlaybackOnStop = true
+  }
+}

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/ext/SimpleExoPlayerExt.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/ext/SimpleExoPlayerExt.kt
@@ -1,0 +1,79 @@
+package com.github.ashutoshgngwr.noice.ext
+
+import android.os.Handler
+import android.os.Looper
+import androidx.core.os.HandlerCompat
+import androidx.media.AudioAttributesCompat
+import com.google.android.exoplayer2.SimpleExoPlayer
+import com.google.android.exoplayer2.audio.AudioAttributes
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.min
+
+
+private const val FADE_CALLBACK_TOKEN = "SimpleExoPlayer.fadeCallbackToken"
+private const val FADE_VOLUME_STEP = 0.005f
+
+/**
+ * Fade in and out effect for [SimpleExoPlayer].
+ *
+ * @param fromVolume initial volume where the fade transition will start
+ * @param toVolume final volume where the fade transition will end
+ * @param duration duration of fade in ms
+ * @param callback callback when fade transition finishes
+ */
+fun SimpleExoPlayer.fade(
+  fromVolume: Float,
+  toVolume: Float,
+  duration: Long,
+  callback: (() -> Unit)? = null
+) {
+  // TODO: the code works for current requirements, but it is problematic. e.g. it cancels the
+  //  previous transition (if on-going) when a new one is scheduled, thus also cancelling its
+  //  callback. This behaviour might not be desired.
+
+  val handler = Handler(Looper.getMainLooper())
+  handler.removeCallbacksAndMessages(FADE_CALLBACK_TOKEN)
+  if (!playWhenReady && !isPlaying) {
+    // edge case where fade is requested but playback is not playing.
+    volume = toVolume
+    callback?.invoke()
+    return
+  }
+
+  val sign = if (toVolume > fromVolume) 1 else -1
+  val steps = 1 + ceil(abs(toVolume - fromVolume) / FADE_VOLUME_STEP).toInt()
+  val period = duration / steps
+  volume = fromVolume
+  for (i in 0 until steps) {
+    HandlerCompat.postDelayed(
+      handler,
+      { volume = min(1f, volume + (sign * FADE_VOLUME_STEP)) },
+      this,
+      i * period
+    )
+  }
+
+  HandlerCompat.postDelayed(handler, {
+    volume = toVolume
+    callback?.invoke()
+  }, FADE_CALLBACK_TOKEN, duration + 1)
+}
+
+/**
+ * Implicitly translates [AudioAttributesCompat] to [AudioAttributes] and sets them on the provided
+ * [SimpleExoPlayer] receiver instance.
+ */
+fun SimpleExoPlayer.setAudioAttributesCompat(
+  attrs: AudioAttributesCompat,
+  handleAudioFocus: Boolean
+) {
+  setAudioAttributes(
+    AudioAttributes.Builder()
+      .setContentType(attrs.contentType)
+      .setFlags(attrs.flags)
+      .setUsage(attrs.usage)
+      .build(),
+    handleAudioFocus,
+  )
+}

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/WakeUpTimerFragment.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/fragment/WakeUpTimerFragment.kt
@@ -1,15 +1,12 @@
 package com.github.ashutoshgngwr.noice.fragment
 
-import android.media.AudioManager
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.content.getSystemService
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.media.AudioManagerCompat
 import com.github.ashutoshgngwr.noice.NoiceApplication
 import com.github.ashutoshgngwr.noice.R
 import com.github.ashutoshgngwr.noice.WakeUpTimerManager
@@ -22,7 +19,6 @@ import java.util.concurrent.TimeUnit
 
 class WakeUpTimerFragment : Fragment() {
 
-  private lateinit var audioManager: AudioManager
   private lateinit var binding: WakeUpTimerFragmentBinding
   private lateinit var presetRepository: PresetRepository
   private lateinit var analyticsProvider: AnalyticsProvider
@@ -48,27 +44,12 @@ class WakeUpTimerFragment : Fragment() {
       binding.timePicker.setIs24HourView(enabled)
     }
 
-    binding.shouldUpdateMediaVolume.setOnCheckedChangeListener { _, enabled ->
-      binding.mediaVolumeSlider.isEnabled = enabled
-    }
-
-    audioManager = requireNotNull(requireContext().getSystemService())
     presetRepository = PresetRepository.newInstance(requireContext())
-    val max = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
-    val min = AudioManagerCompat.getStreamMinVolume(audioManager, AudioManager.STREAM_MUSIC)
-
-    binding.mediaVolumeSlider.isEnabled = binding.shouldUpdateMediaVolume.isChecked
-    binding.mediaVolumeSlider.valueFrom = min.toFloat()
-    binding.mediaVolumeSlider.valueTo = max.toFloat()
-    binding.mediaVolumeSlider.stepSize = 1f
-    binding.mediaVolumeSlider.setLabelFormatter { "${(it * 100).toInt() / max}%" }
 
     WakeUpTimerManager.get(requireContext())?.also {
       if (it.atMillis > System.currentTimeMillis()) {
         selectedPresetID = it.presetID
         selectedTime = it.atMillis
-        binding.shouldUpdateMediaVolume.isChecked = it.shouldUpdateMediaVolume
-        binding.mediaVolumeSlider.value = it.mediaVolume.toFloat()
       }
     }
 
@@ -169,12 +150,7 @@ class WakeUpTimerFragment : Fragment() {
     if (isTimerValid) {
       WakeUpTimerManager.set(
         requireContext(),
-        WakeUpTimerManager.Timer(
-          requireNotNull(selectedPresetID),
-          selectedTime,
-          binding.shouldUpdateMediaVolume.isChecked,
-          binding.mediaVolumeSlider.value.toInt()
-        )
+        WakeUpTimerManager.Timer(requireNotNull(selectedPresetID), selectedTime)
       )
     } else {
       WakeUpTimerManager.cancel(requireContext())
@@ -264,8 +240,5 @@ class WakeUpTimerFragment : Fragment() {
   private fun resetControls() {
     loadSelectedPresetID()
     selectedTime = 0
-    binding.shouldUpdateMediaVolume.isChecked = false
-    binding.mediaVolumeSlider.value =
-      audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).toFloat()
   }
 }

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/playback/PlaybackController.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/playback/PlaybackController.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import androidx.core.content.edit
 import androidx.core.os.bundleOf
@@ -50,6 +51,8 @@ object PlaybackController {
   private const val RC_RESUME = 0x3C
   private const val RC_PAUSE = 0x3D
   private const val RC_STOP = 0x3E
+
+  private val handler = Handler(Looper.getMainLooper())
 
   fun buildResumeActionPendingIntent(context: Context): PendingIntent {
     return buildSimpleActionPendingIntent(context, ACTION_RESUME_PLAYBACK, RC_RESUME)
@@ -117,12 +120,7 @@ object PlaybackController {
     }
   }
 
-  fun handleServiceIntent(
-    context: Context,
-    playerManager: PlayerManager,
-    intent: Intent,
-    handler: Handler
-  ) {
+  fun handleServiceIntent(context: Context, playerManager: PlayerManager, intent: Intent) {
     when (intent.action) {
       ACTION_RESUME_PLAYBACK -> {
         playerManager.resume()
@@ -330,7 +328,7 @@ object PlaybackController {
     return max(atUptimeMillis - SystemClock.uptimeMillis(), 0)
   }
 
-  fun clearAutoStopCallback(handler: Handler) {
+  fun clearAutoStopCallback() {
     handler.removeCallbacksAndMessages(AUTO_STOP_CALLBACK_TOKEN)
   }
 

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/playback/PlaybackController.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/playback/PlaybackController.kt
@@ -45,7 +45,6 @@ object PlaybackController {
 
   internal val PREF_LAST_SCHEDULED_STOP_TIME = "${TAG}.scheduled_stop_time"
 
-  private const val RC_ALARM = 0x39
   private const val RC_SKIP_PREV = 0x3A
   private const val RC_SKIP_NEXT = 0x3B
   private const val RC_RESUME = 0x3C
@@ -97,15 +96,6 @@ object PlaybackController {
     return buildPendingIntent(context, intent, requestCode)
   }
 
-  fun buildAlarmPendingIntent(context: Context, presetID: String?): PendingIntent {
-    val intent = Intent(context, MediaPlayerService::class.java)
-      .setAction(ACTION_PLAY_PRESET)
-      .putExtra(EXTRA_PRESET_ID, presetID)
-      .putExtra(EXTRA_AUDIO_USAGE, AudioAttributesCompat.USAGE_ALARM)
-
-    return buildPendingIntent(context, intent, RC_ALARM)
-  }
-
   private fun buildPendingIntent(
     context: Context,
     intent: Intent,
@@ -143,11 +133,6 @@ object PlaybackController {
       }
 
       ACTION_PLAY_PRESET -> {
-        // update stream before playing preset. This will cause a sudden volume change if the
-        // something is already playing via different audio stream.
-        val audioUsage = intent.getIntExtra(EXTRA_AUDIO_USAGE, AudioAttributesCompat.USAGE_MEDIA)
-        playerManager.setAudioUsage(audioUsage)
-
         intent.getStringExtra(EXTRA_PRESET_ID)?.also { playerManager.playPreset(it) }
         intent.data?.also { playerManager.playPreset(it) }
         logEvent(context, "preset_playback", bundleOf("items_count" to playerManager.playerCount()))
@@ -264,7 +249,7 @@ object PlaybackController {
   /**
    * Sends the start command to the service with [ACTION_PLAY_PRESET].
    */
-  fun playPreset(context: Context, presetID: String?) {
+  fun playPreset(context: Context, presetID: String) {
     context.startService(
       Intent(context, MediaPlayerService::class.java)
         .setAction(ACTION_PLAY_PRESET)

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/playback/Player.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/playback/Player.kt
@@ -19,7 +19,6 @@ class Player(val soundKey: String, playbackStrategyFactory: PlaybackStrategyFact
 
   companion object {
     private val TAG = Player::class.simpleName
-    private val DELAYED_PLAYBACK_CALLBACK_TOKEN = "${Player::class.simpleName}.playback_callback"
 
     const val DEFAULT_VOLUME = 4
     const val MAX_VOLUME = 25
@@ -82,9 +81,7 @@ class Player(val soundKey: String, playbackStrategyFactory: PlaybackStrategyFact
     playbackStrategy.play()
     val delay = nextInt(MIN_TIME_PERIOD, 1 + timePeriod) * 1000L
     Log.d(TAG, "scheduling delayed playback with ${delay}ms delay")
-    HandlerCompat.postDelayed(
-      handler, this::playAndRegisterDelayedCallback, DELAYED_PLAYBACK_CALLBACK_TOKEN, delay
-    )
+    HandlerCompat.postDelayed(handler, this::playAndRegisterDelayedCallback, this, delay)
   }
 
   /**
@@ -95,7 +92,7 @@ class Player(val soundKey: String, playbackStrategyFactory: PlaybackStrategyFact
     isPlaying = false
     playbackStrategy.pause()
     if (!sound.isLooping) {
-      handler.removeCallbacksAndMessages(DELAYED_PLAYBACK_CALLBACK_TOKEN)
+      handler.removeCallbacksAndMessages(this)
     }
   }
 
@@ -107,7 +104,7 @@ class Player(val soundKey: String, playbackStrategyFactory: PlaybackStrategyFact
     isPlaying = false
     playbackStrategy.stop()
     if (!sound.isLooping) {
-      handler.removeCallbacksAndMessages(DELAYED_PLAYBACK_CALLBACK_TOKEN)
+      handler.removeCallbacksAndMessages(this)
     }
   }
 

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/playback/Player.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/playback/Player.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.core.os.HandlerCompat
+import androidx.media.AudioAttributesCompat
 import com.github.ashutoshgngwr.noice.model.Sound
 import com.github.ashutoshgngwr.noice.playback.strategy.PlaybackStrategy
 import com.github.ashutoshgngwr.noice.playback.strategy.PlaybackStrategyFactory
@@ -110,6 +111,10 @@ class Player(val soundKey: String, playbackStrategyFactory: PlaybackStrategyFact
     }
   }
 
+  internal fun setAudioAttributes(attrs: AudioAttributesCompat) {
+    playbackStrategy.setAudioAttributes(attrs)
+  }
+
   /**
    * [updatePlaybackStrategy] updates the [PlaybackStrategy] used by the [Player] instance. All subsequent
    * player control commands are sent to the new [PlaybackStrategy]. It also sends setVolume command
@@ -117,8 +122,6 @@ class Player(val soundKey: String, playbackStrategyFactory: PlaybackStrategyFact
    * command on the new [PlaybackStrategy].
    */
   internal fun updatePlaybackStrategy(playbackStrategyFactory: PlaybackStrategyFactory) {
-    // pause then stop just to prevent the fade-out transition from LocalSoundPlayer
-    playbackStrategy.pause()
     playbackStrategy.stop()
     playbackStrategy = playbackStrategyFactory.newInstance(sound).also {
       it.setVolume(volume.toFloat() / MAX_VOLUME)

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/playback/PlayerManager.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/playback/PlayerManager.kt
@@ -138,6 +138,7 @@ class PlayerManager(private val context: Context, private val mediaSession: Medi
       return
     }
 
+    Log.d(TAG, "setAudioUsage(): usage = $usage")
     audioAttributes = AudioAttributesCompat.Builder()
       .setContentType(AudioAttributesCompat.CONTENT_TYPE_MOVIE)
       .setUsage(usage)
@@ -157,6 +158,9 @@ class PlayerManager(private val context: Context, private val mediaSession: Medi
 
     if (hasAudioFocus) {
       abandonAudioFocus()
+    }
+
+    if (state == PlaybackStateCompat.STATE_PLAYING) {
       requestAudioFocus()
     }
   }
@@ -291,6 +295,10 @@ class PlayerManager(private val context: Context, private val mediaSession: Medi
    * It doesn't release any underlying resources.
    */
   private fun pauseIndefinitely() {
+    if (players.isEmpty() && state != PlaybackStateCompat.STATE_PLAYING) {
+      return
+    }
+
     state = PlaybackStateCompat.STATE_PAUSED
     players.values.forEach {
       it.pause()
@@ -305,6 +313,10 @@ class PlayerManager(private val context: Context, private val mediaSession: Medi
    * delayed callback to release all underlying resources after 5 minutes.
    */
   fun pause() {
+    if (players.isEmpty() && state != PlaybackStateCompat.STATE_PLAYING) {
+      return
+    }
+
     pauseIndefinitely()
     Log.d(TAG, "pause(): scheduling stop callback")
     handler.removeCallbacksAndMessages(DELAYED_STOP_CALLBACK_TOKEN) // clear previous callbacks

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/playback/PlayerManager.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/playback/PlayerManager.kt
@@ -29,7 +29,7 @@ typealias PlaybackUpdateListener = (state: Int, players: Map<String, Player>) ->
  * It manages Android's audio focus implicitly. It also manages Playback routing to
  * cast enabled devices on-demand.
  */
-class PlayerManager(context: Context, private val mediaSession: MediaSessionCompat) :
+class PlayerManager(private val context: Context, private val mediaSession: MediaSessionCompat) :
   AudioManager.OnAudioFocusChangeListener {
 
   companion object {
@@ -46,28 +46,16 @@ class PlayerManager(context: Context, private val mediaSession: MediaSessionComp
   private var resumeOnFocusGain = false
   private var playbackUpdateListener: PlaybackUpdateListener? = null
 
+  private lateinit var audioAttributes: AudioAttributesCompat
+  private lateinit var audioFocusRequest: AudioFocusRequestCompat
+  private lateinit var playbackStrategyFactory: PlaybackStrategyFactory
+
   private val players = HashMap<String, Player>(Sound.LIBRARY.size)
   private val handler = Handler(Looper.getMainLooper())
   private val presetRepository = PresetRepository.newInstance(context)
   private val settingsRepository = SettingsRepository.newInstance(context)
   private val analyticsProvider = NoiceApplication.of(context).getAnalyticsProvider()
-
   private val audioManager = requireNotNull(context.getSystemService<AudioManager>())
-  private val audioAttributes = AudioAttributesCompat.Builder()
-    .setContentType(AudioAttributesCompat.CONTENT_TYPE_MOVIE)
-    .setUsage(AudioAttributesCompat.USAGE_GAME)
-    .setLegacyStreamType(AudioManager.STREAM_MUSIC)
-    .build()
-
-  private val audioFocusRequest = AudioFocusRequestCompat
-    .Builder(AudioManagerCompat.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
-    .setAudioAttributes(audioAttributes)
-    .setOnAudioFocusChangeListener(this, handler)
-    .setWillPauseWhenDucked(false)
-    .build()
-
-  private var playbackStrategyFactory: PlaybackStrategyFactory =
-    LocalPlaybackStrategyFactory(context, audioAttributes)
 
   private val playbackStateBuilder = PlaybackStateCompat.Builder()
     .setActions(
@@ -85,7 +73,7 @@ class PlayerManager(context: Context, private val mediaSession: MediaSessionComp
       onSessionBegin {
         Log.d(TAG, "onSessionBegin(): switching playback to CastPlaybackStrategy")
         playbackStrategyFactory = getPlaybackStrategyFactory()
-        updatePlaybackStrategies()
+        players.values.forEach { it.updatePlaybackStrategy(playbackStrategyFactory) }
         mediaSession.setPlaybackToRemote(getVolumeProvider())
         analyticsProvider.logCastSessionStartEvent()
       }
@@ -97,14 +85,15 @@ class PlayerManager(context: Context, private val mediaSession: MediaSessionComp
         if (playbackStrategyFactory !is LocalPlaybackStrategyFactory) {
           Log.d(TAG, "onSessionEnd(): switching playback to LocalPlaybackStrategy")
           playbackStrategyFactory = LocalPlaybackStrategyFactory(context, audioAttributes)
+          players.values.forEach { it.updatePlaybackStrategy(playbackStrategyFactory) }
           mediaSession.setPlaybackToLocal(AudioManager.STREAM_MUSIC)
-          updatePlaybackStrategies()
           analyticsProvider.logCastSessionEndEvent()
         }
       }
     }
 
   init {
+    setAudioUsage(AudioAttributesCompat.USAGE_MEDIA)
     mediaSession.setCallback(object : MediaSessionCompat.Callback() {
       override fun onPlay() = resume()
       override fun onStop() = stop()
@@ -141,6 +130,34 @@ class PlayerManager(context: Context, private val mediaSession: MediaSessionComp
         playbackDelayed = false
         pauseIndefinitely()
       }
+    }
+  }
+
+  internal fun setAudioUsage(@AudioAttributesCompat.AttributeUsage usage: Int) {
+    if (this::audioAttributes.isInitialized && usage == audioAttributes.usage) {
+      return
+    }
+
+    audioAttributes = AudioAttributesCompat.Builder()
+      .setContentType(AudioAttributesCompat.CONTENT_TYPE_MOVIE)
+      .setUsage(usage)
+      .build()
+
+    audioFocusRequest = AudioFocusRequestCompat
+      .Builder(AudioManagerCompat.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+      .setAudioAttributes(audioAttributes)
+      .setOnAudioFocusChangeListener(this, handler)
+      .setWillPauseWhenDucked(false)
+      .build()
+
+    players.values.forEach { it.setAudioAttributes(audioAttributes) }
+    if (!this::playbackStrategyFactory.isInitialized || playbackStrategyFactory is LocalPlaybackStrategyFactory) {
+      playbackStrategyFactory = LocalPlaybackStrategyFactory(context, audioAttributes)
+    }
+
+    if (hasAudioFocus) {
+      abandonAudioFocus()
+      requestAudioFocus()
     }
   }
 
@@ -314,14 +331,6 @@ class PlayerManager(context: Context, private val mediaSession: MediaSessionComp
       // request audio focus only if audio focus is not delayed from any previous requests
       requestAudioFocus()
     }
-  }
-
-  /**
-   * Attempts to recreate the [PlaybackStrategyFactory] for all [Player]s using the current
-   * [PlaybackStrategyFactory] instance
-   */
-  private fun updatePlaybackStrategies() {
-    players.values.forEach { it.updatePlaybackStrategy(playbackStrategyFactory) }
   }
 
   /**

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/playback/strategy/LocalPlaybackStrategy.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/playback/strategy/LocalPlaybackStrategy.kt
@@ -2,21 +2,16 @@ package com.github.ashutoshgngwr.noice.playback.strategy
 
 import android.content.Context
 import android.net.Uri
-import android.os.Handler
-import android.os.Looper
-import androidx.core.os.HandlerCompat
 import androidx.media.AudioAttributesCompat
+import com.github.ashutoshgngwr.noice.ext.fade
+import com.github.ashutoshgngwr.noice.ext.setAudioAttributesCompat
 import com.github.ashutoshgngwr.noice.model.Sound
 import com.github.ashutoshgngwr.noice.repository.SettingsRepository
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.SimpleExoPlayer
-import com.google.android.exoplayer2.audio.AudioAttributes
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
 import com.google.android.exoplayer2.util.Util
-import kotlin.math.abs
-import kotlin.math.ceil
-import kotlin.math.min
 
 /**
  * [LocalPlaybackStrategy] implements [PlaybackStrategy] which plays the media locally
@@ -29,23 +24,19 @@ class LocalPlaybackStrategy(
 ) : PlaybackStrategy {
 
   companion object {
-    private const val FADE_VOLUME_STEP = 0.005f
-
     // a smaller default used when changing volume of an active player.
     private const val VOLUME_ADJUSTMENT_FADE_DURATION = 750L
   }
 
-  private val handler = Handler(Looper.getMainLooper())
-  private val players = sound.src.map { initPlayer(context, it, sound.isLooping, audioAttributes) }
+  private val players = sound.src.map { initPlayer(context, it, sound.isLooping) }
   private val settingsRepository = SettingsRepository.newInstance(context)
   private var volume: Float = 0f
 
-  private fun initPlayer(
-    context: Context,
-    src: String,
-    isLooping: Boolean,
-    audioAttributes: AudioAttributesCompat
-  ): SimpleExoPlayer {
+  init {
+    setAudioAttributes(audioAttributes)
+  }
+
+  private fun initPlayer(context: Context, src: String, isLooping: Boolean): SimpleExoPlayer {
     return SimpleExoPlayer.Builder(context)
       .build()
       .apply {
@@ -54,15 +45,6 @@ class LocalPlaybackStrategy(
         } else {
           ExoPlayer.REPEAT_MODE_OFF
         }
-
-        setAudioAttributes(
-          AudioAttributes.Builder()
-            .setContentType(audioAttributes.contentType)
-            .setFlags(audioAttributes.flags)
-            .setUsage(audioAttributes.usage)
-            .build(),
-          false
-        )
 
         prepare(
           Util.getUserAgent(context, context.packageName).let { userAgent ->
@@ -87,7 +69,7 @@ class LocalPlaybackStrategy(
       player.playWhenReady = true
       // an internal feature of the LocalPlaybackStrategy is that it won't fade-in non-looping sounds
       if (player.repeatMode == ExoPlayer.REPEAT_MODE_ONE) {
-        player.fade(0f, volume)
+        player.fade(0f, volume, settingsRepository.getSoundFadeDurationInMillis())
       }
     }
   }
@@ -106,48 +88,14 @@ class LocalPlaybackStrategy(
         continue
       }
 
-      player.fade(player.volume, 0f) {
+      player.fade(player.volume, 0f, settingsRepository.getSoundFadeDurationInMillis()) {
         player.playWhenReady = false
         player.release()
       }
     }
   }
 
-  /**
-   * an extension to [SimpleExoPlayer] for fade in and out effects
-   *
-   * @param fromVolume initial volume where the fade transition will start
-   * @param toVolume final volume where the fade transition will end
-   * @param duration duration of fade in ms
-   * @param callback callback when fade transition finishes
-   */
-  private fun SimpleExoPlayer.fade(
-    fromVolume: Float,
-    toVolume: Float,
-    duration: Long = settingsRepository.getSoundFadeDurationInMillis(),
-    callback: () -> Unit = { }
-  ) {
-    handler.removeCallbacksAndMessages(this)
-    if (!playWhenReady && !isPlaying) {
-      // edge case where fade is requested but playback is not playing.
-      volume = toVolume
-      callback.invoke()
-      return
-    }
-
-    val sign = if (toVolume > fromVolume) 1 else -1
-    val steps = 1 + ceil(abs(toVolume - fromVolume) / FADE_VOLUME_STEP).toInt()
-    val period = duration / steps
-    volume = fromVolume
-    for (i in 0 until steps) {
-      HandlerCompat.postDelayed(
-        handler, { volume = min(1f, volume + (sign * FADE_VOLUME_STEP)) }, this, i * period
-      )
-    }
-
-    HandlerCompat.postDelayed(handler, {
-      volume = toVolume
-      callback.invoke()
-    }, this, duration + 1)
+  override fun setAudioAttributes(attrs: AudioAttributesCompat) {
+    players.forEach { it.setAudioAttributesCompat(attrs, false) }
   }
 }

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/playback/strategy/LocalPlaybackStrategy.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/playback/strategy/LocalPlaybackStrategy.kt
@@ -96,6 +96,6 @@ class LocalPlaybackStrategy(
   }
 
   override fun setAudioAttributes(attrs: AudioAttributesCompat) {
-    players.forEach { it.setAudioAttributesCompat(attrs, false) }
+    players.forEach { it.setAudioAttributesCompat(attrs) }
   }
 }

--- a/app/src/main/java/com/github/ashutoshgngwr/noice/playback/strategy/PlaybackStrategy.kt
+++ b/app/src/main/java/com/github/ashutoshgngwr/noice/playback/strategy/PlaybackStrategy.kt
@@ -1,5 +1,7 @@
 package com.github.ashutoshgngwr.noice.playback.strategy
 
+import androidx.media.AudioAttributesCompat
+
 /**
  * [PlaybackStrategy] interface is the generic type used by the SoundPlayer class to control the
  * underlying playback mechanism
@@ -26,4 +28,9 @@ interface PlaybackStrategy {
    * stops playing the sound and releases the underlying sound resource.
    */
   fun stop()
+
+  /**
+   * Sets audio attributes for the underlying playback mechanism.
+   */
+  fun setAudioAttributes(attrs: AudioAttributesCompat)
 }

--- a/app/src/main/res/layout/alarm_ringer_activity.xml
+++ b/app/src/main/res/layout/alarm_ringer_activity.xml
@@ -67,4 +67,16 @@
     android:layout_height="0dp"
     android:layout_weight="1" />
 
+  <TextView
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="end"
+    android:drawablePadding="4dp"
+    android:gravity="center_vertical"
+    android:text="@string/app_name"
+    android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+    android:textColor="@color/material_on_background_disabled"
+    app:drawableEndCompat="@drawable/ic_launcher_24dp"
+    app:drawableTint="@color/material_on_background_disabled" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/alarm_ringer_activity.xml
+++ b/app/src/main/res/layout/alarm_ringer_activity.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:gravity="center"
+  android:orientation="vertical"
+  android:padding="16dp">
+
+  <Space
+    android:layout_width="wrap_content"
+    android:layout_height="0dp"
+    android:layout_weight="1" />
+
+  <TextView
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/wake_up_timer"
+    android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5" />
+
+  <Space
+    android:layout_width="wrap_content"
+    android:layout_height="16dp" />
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal|bottom"
+    android:orientation="horizontal">
+
+    <TextClock
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:format12Hour="hh:mm"
+      android:format24Hour="hh:mm"
+      android:textAppearance="@style/TextAppearance.MaterialComponents.Headline2"
+      tools:text="03:10" />
+
+    <TextClock
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:drawableTop="@drawable/ic_nav_wake_up_timer"
+      android:format12Hour=" a"
+      android:format24Hour=""
+      android:textAllCaps="true"
+      android:textAppearance="@style/TextAppearance.MaterialComponents.Headline4"
+      android:textStyle="bold"
+      tools:text=" pm" />
+
+  </LinearLayout>
+
+  <Space
+    android:layout_width="wrap_content"
+    android:layout_height="0dp"
+    android:layout_weight="1" />
+
+  <com.ncorti.slidetoact.SlideToActView
+    android:id="@+id/dismiss_slider"
+    style="@style/Widget.App.AlarmRinger.DismissSlider"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:text="@string/dismiss" />
+
+  <Space
+    android:layout_width="wrap_content"
+    android:layout_height="0dp"
+    android:layout_weight="1" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/wake_up_timer_fragment.xml
+++ b/app/src/main/res/layout/wake_up_timer_fragment.xml
@@ -43,29 +43,9 @@
       android:text="@string/use_24h_format"
       app:switchPadding="15dp" />
 
-    <TextView
+    <Space
       android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="15dp"
-      android:drawablePadding="5dp"
-      android:text="@string/device_media_volume"
-      android:textAppearance="?textAppearanceBody1"
-      app:drawableStartCompat="@drawable/ic_action_volume"
-      app:drawableTint="@color/primary" />
-
-    <CheckBox
-      android:id="@+id/should_update_media_volume"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="15dp"
-      android:paddingHorizontal="5dp"
-      android:text="@string/should_update_media_volume" />
-
-    <com.google.android.material.slider.Slider
-      android:id="@+id/media_volume_slider"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginVertical="10dp" />
+      android:layout_height="24dp" />
 
     <LinearLayout
       android:layout_width="match_parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -112,4 +112,18 @@
     <item name="aboutElementIconTint">@color/primary_dark</item>
   </style>
 
+  <style name="Widget.App.AlarmRinger.DismissSlider" parent="SlideToActView">
+    <item name="slider_height">72dp</item>
+    <item name="border_radius">28dp</item>
+    <item name="inner_color">@color/background</item>
+    <item name="outer_color">@color/accent</item>>
+    <item name="text_appearance">@style/TextAppearance.App.AlarmRinger.DismissSlider</item>
+  </style>
+
+  <style name="TextAppearance.App.AlarmRinger.DismissSlider" parent="TextAppearance.MaterialComponents.Headline6">
+    <item name="android:textColor">@color/background</item>
+    <item name="android:textAllCaps">true</item>
+    <item name="android:letterSpacing">0.1</item>
+  </style>
+
 </resources>

--- a/app/src/playstore/java/com/github/ashutoshgngwr/noice/playback/strategy/CastPlaybackStrategy.kt
+++ b/app/src/playstore/java/com/github/ashutoshgngwr/noice/playback/strategy/CastPlaybackStrategy.kt
@@ -1,5 +1,6 @@
 package com.github.ashutoshgngwr.noice.playback.strategy
 
+import androidx.media.AudioAttributesCompat
 import com.github.ashutoshgngwr.noice.model.Sound
 import com.google.android.gms.cast.framework.CastSession
 import com.google.gson.GsonBuilder
@@ -59,6 +60,8 @@ class CastPlaybackStrategy(
   override fun stop() {
     notifyChanges(ACTION_STOP)
   }
+
+  override fun setAudioAttributes(attrs: AudioAttributesCompat) = Unit
 
   private fun notifyChanges(action: String?) {
     session.sendMessage(

--- a/app/src/test/java/com/github/ashutoshgngwr/noice/MediaPlayerServiceTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/MediaPlayerServiceTest.kt
@@ -101,7 +101,7 @@ class MediaPlayerServiceTest {
     serviceController.create().destroy()
     ShadowLooper.idleMainLooper()
     assertFalse(ShadowPowerManager.getLatestWakeLock().isHeld)
-    verify(exactly = 1) { PlaybackController.clearAutoStopCallback(any()) }
+    verify(exactly = 1) { PlaybackController.clearAutoStopCallback() }
   }
 
   @Test
@@ -109,7 +109,7 @@ class MediaPlayerServiceTest {
     mockkObject(PlaybackController)
     serviceController.create().startCommand(0, 0)
     verify(exactly = 1) {
-      PlaybackController.handleServiceIntent(any(), any(), mockServiceIntent, any())
+      PlaybackController.handleServiceIntent(any(), any(), mockServiceIntent)
     }
   }
 }

--- a/app/src/test/java/com/github/ashutoshgngwr/noice/ext/SimpleExoPlayerExtTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/ext/SimpleExoPlayerExtTest.kt
@@ -1,0 +1,47 @@
+package com.github.ashutoshgngwr.noice.ext
+
+import com.google.android.exoplayer2.SimpleExoPlayer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(RobolectricTestRunner::class)
+class SimpleExoPlayerExtTest {
+
+  private lateinit var player: SimpleExoPlayer
+
+  @Before
+  fun setup() {
+    player = mockk(relaxed = true)
+  }
+
+  @Test
+  fun testFade() {
+    every { player.playWhenReady } returns true
+
+    val callback: () -> Unit = mockk(relaxed = true)
+    player.fade(0f, 1f, 1000L, callback)
+
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    val volumeSlots = mutableListOf<Float>()
+    verify(atLeast = 3) { player.volume = capture(volumeSlots) }
+    Assert.assertTrue(
+      "volume should increase with each step",
+      volumeSlots.first() < volumeSlots.last()
+    )
+
+    Assert.assertEquals(
+      "volume should be set to desired value on finish",
+      1f, volumeSlots.last(),
+    )
+
+    verify(exactly = 1) { callback.invoke() }
+  }
+}

--- a/app/src/test/java/com/github/ashutoshgngwr/noice/playback/PlaybackControllerTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/playback/PlaybackControllerTest.kt
@@ -109,22 +109,6 @@ class PlaybackControllerTest {
   }
 
   @Test
-  fun testBuildAlarmPendingIntent() {
-    val inputShouldUpdateMediaVolume = arrayOf(true, false)
-    for (i in inputShouldUpdateMediaVolume.indices) {
-      val presetID = "test-preset-id"
-      val pendingIntent = PlaybackController.buildAlarmPendingIntent(
-        ApplicationProvider.getApplicationContext(), presetID
-      )
-
-      val intent = shadowOf(pendingIntent).savedIntent
-      assertEquals(MediaPlayerService::class.qualifiedName, intent.component?.className)
-      assertEquals(PlaybackController.ACTION_PLAY_PRESET, intent.action)
-      assertEquals(presetID, intent.getStringExtra(PlaybackController.EXTRA_PRESET_ID))
-    }
-  }
-
-  @Test
   fun testHandleServiceIntent_withResumePlaybackAction() {
     PlaybackController.handleServiceIntent(
       ApplicationProvider.getApplicationContext(),
@@ -169,18 +153,15 @@ class PlaybackControllerTest {
     )
 
     val uri = Uri.parse("test")
-    val audioUsage = AudioAttributesCompat.USAGE_ALARM
     PlaybackController.handleServiceIntent(
       ApplicationProvider.getApplicationContext(),
       mockPlayerManager,
       Intent(PlaybackController.ACTION_PLAY_PRESET)
-        .setData(uri)
-        .putExtra(PlaybackController.EXTRA_AUDIO_USAGE, audioUsage),
+        .setData(uri),
     )
 
     verifyOrder {
       mockPlayerManager.playPreset(presetID)
-      mockPlayerManager.setAudioUsage(audioUsage)
       mockPlayerManager.playPreset(uri)
     }
   }

--- a/app/src/test/java/com/github/ashutoshgngwr/noice/playback/PlaybackControllerTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/playback/PlaybackControllerTest.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
-import android.os.Handler
-import android.os.Looper
 import android.os.SystemClock
 import androidx.media.AudioAttributesCompat
 import androidx.preference.PreferenceManager
@@ -132,7 +130,6 @@ class PlaybackControllerTest {
       ApplicationProvider.getApplicationContext(),
       mockPlayerManager,
       Intent(PlaybackController.ACTION_RESUME_PLAYBACK),
-      mockk()
     )
 
     verify(exactly = 1) { mockPlayerManager.resume() }
@@ -144,7 +141,6 @@ class PlaybackControllerTest {
       ApplicationProvider.getApplicationContext(),
       mockPlayerManager,
       Intent(PlaybackController.ACTION_PAUSE_PLAYBACK),
-      mockk()
     )
 
     verify(exactly = 1) { mockPlayerManager.pause() }
@@ -156,7 +152,6 @@ class PlaybackControllerTest {
       ApplicationProvider.getApplicationContext(),
       mockPlayerManager,
       Intent(PlaybackController.ACTION_STOP_PLAYBACK),
-      mockk()
     )
 
     verify(exactly = 1) { mockPlayerManager.stop() }
@@ -171,7 +166,6 @@ class PlaybackControllerTest {
       mockPlayerManager,
       Intent(PlaybackController.ACTION_PLAY_PRESET)
         .putExtra(PlaybackController.EXTRA_PRESET_ID, presetID),
-      mockk()
     )
 
     val uri = Uri.parse("test")
@@ -182,7 +176,6 @@ class PlaybackControllerTest {
       Intent(PlaybackController.ACTION_PLAY_PRESET)
         .setData(uri)
         .putExtra(PlaybackController.EXTRA_AUDIO_USAGE, audioUsage),
-      mockk()
     )
 
     verifyOrder {
@@ -204,7 +197,6 @@ class PlaybackControllerTest {
         .putExtra(PlaybackController.EXTRA_FILTER_SOUNDS_BY_TAG, tag)
         .putExtra(PlaybackController.EXTRA_RANDOM_PRESET_MIN_SOUNDS, minSounds)
         .putExtra(PlaybackController.EXTRA_RANDOM_PRESET_MAX_SOUNDS, maxSounds),
-      mockk()
     )
 
     verify(exactly = 1) { mockPlayerManager.playRandomPreset(tag, minSounds..maxSounds) }
@@ -218,7 +210,6 @@ class PlaybackControllerTest {
       mockPlayerManager,
       Intent(PlaybackController.ACTION_PLAY_SOUND)
         .putExtra(PlaybackController.EXTRA_SOUND_KEY, soundKey),
-      mockk()
     )
 
     verify(exactly = 1) { mockPlayerManager.play(soundKey) }
@@ -232,7 +223,6 @@ class PlaybackControllerTest {
       mockPlayerManager,
       Intent(PlaybackController.ACTION_STOP_SOUND)
         .putExtra(PlaybackController.EXTRA_SOUND_KEY, soundKey),
-      mockk()
     )
 
     verify(exactly = 1) { mockPlayerManager.stop(soundKey) }
@@ -245,7 +235,6 @@ class PlaybackControllerTest {
       mockPlayerManager,
       Intent(PlaybackController.ACTION_SCHEDULE_STOP_PLAYBACK)
         .putExtra(PlaybackController.EXTRA_AT_UPTIME_MILLIS, SystemClock.uptimeMillis() + 100),
-      Handler(Looper.getMainLooper())
     )
 
     verify { mockPlayerManager wasNot called }
@@ -255,13 +244,11 @@ class PlaybackControllerTest {
 
   @Test
   fun testHandleServiceIntent_withScheduleStopPlaybackAction_onCancel() {
-    val handler = Handler(Looper.getMainLooper())
     PlaybackController.handleServiceIntent(
       ApplicationProvider.getApplicationContext(),
       mockPlayerManager,
       Intent(PlaybackController.ACTION_SCHEDULE_STOP_PLAYBACK)
         .putExtra(PlaybackController.EXTRA_AT_UPTIME_MILLIS, SystemClock.uptimeMillis() + 1000),
-      handler
     )
 
     PlaybackController.handleServiceIntent(
@@ -269,7 +256,6 @@ class PlaybackControllerTest {
       mockPlayerManager,
       Intent(PlaybackController.ACTION_SCHEDULE_STOP_PLAYBACK)
         .putExtra(PlaybackController.EXTRA_AT_UPTIME_MILLIS, SystemClock.uptimeMillis() - 1000),
-      handler
     )
 
     ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
@@ -284,7 +270,6 @@ class PlaybackControllerTest {
         mockPlayerManager,
         Intent(PlaybackController.ACTION_SKIP_PRESET)
           .putExtra(PlaybackController.EXTRA_SKIP_DIRECTION, input),
-        mockk()
       )
 
       verify(exactly = 1) { mockPlayerManager.skipPreset(input) }
@@ -297,7 +282,6 @@ class PlaybackControllerTest {
       ApplicationProvider.getApplicationContext(),
       mockPlayerManager,
       Intent(PlaybackController.ACTION_REQUEST_UPDATE_EVENT),
-      mockk()
     )
 
     verify(exactly = 1) { mockPlayerManager.callPlaybackUpdateListener() }
@@ -310,7 +294,6 @@ class PlaybackControllerTest {
       mockPlayerManager,
       Intent(PlaybackController.ACTION_SET_AUDIO_USAGE)
         .putExtra(PlaybackController.EXTRA_AUDIO_USAGE, audioUsage),
-      mockk()
     )
 
     verify(exactly = 1) { mockPlayerManager.setAudioUsage(audioUsage) }
@@ -322,7 +305,6 @@ class PlaybackControllerTest {
       ApplicationProvider.getApplicationContext(),
       mockPlayerManager,
       Intent(),
-      mockk()
     )
 
     verify { mockPlayerManager wasNot called }
@@ -528,16 +510,14 @@ class PlaybackControllerTest {
 
   @Test
   fun testClearAutoStopCallback() {
-    val handler = Handler(Looper.getMainLooper())
     PlaybackController.handleServiceIntent(
       mockk(),
       mockPlayerManager,
       Intent(PlaybackController.ACTION_SCHEDULE_STOP_PLAYBACK)
         .putExtra(PlaybackController.EXTRA_AT_UPTIME_MILLIS, SystemClock.uptimeMillis() + 1000),
-      handler
     )
 
-    PlaybackController.clearAutoStopCallback(handler)
+    PlaybackController.clearAutoStopCallback()
     ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
     verify { mockPlayerManager wasNot called }
   }

--- a/app/src/test/java/com/github/ashutoshgngwr/noice/playback/PlayerManagerTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/playback/PlayerManagerTest.kt
@@ -4,14 +4,15 @@ import android.content.Context
 import android.media.AudioManager
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
+import androidx.media.AudioAttributesCompat
 import androidx.media.AudioManagerCompat
 import androidx.media.VolumeProviderCompat
 import androidx.test.core.app.ApplicationProvider
 import com.github.ashutoshgngwr.noice.NoiceApplication
-import com.github.ashutoshgngwr.noice.provider.CastAPIProvider
 import com.github.ashutoshgngwr.noice.model.Preset
 import com.github.ashutoshgngwr.noice.model.Sound
 import com.github.ashutoshgngwr.noice.playback.strategy.PlaybackStrategyFactory
+import com.github.ashutoshgngwr.noice.provider.CastAPIProvider
 import com.github.ashutoshgngwr.noice.repository.SettingsRepository
 import com.github.ashutoshgngwr.noice.shadow.ShadowMediaSession
 import com.github.ashutoshgngwr.noice.shadow.ShadowMediaSessionCompat
@@ -342,5 +343,17 @@ class PlayerManagerTest {
     playerManager.setPlaybackUpdateListener(listener)
     playerManager.callPlaybackUpdateListener()
     verify(exactly = 1) { listener.invoke(any(), any()) }
+  }
+
+  @Test
+  fun testSetAudioUsage() {
+    val mockPlayer = players.getValue("test")
+    val audioUsage = AudioAttributesCompat.USAGE_ALARM
+    playerManager.setAudioUsage(audioUsage)
+    verify(exactly = 1) {
+      mockPlayer.setAudioAttributes(withArg {
+        assertEquals(audioUsage, it.usage)
+      })
+    }
   }
 }

--- a/app/src/test/java/com/github/ashutoshgngwr/noice/playback/PlayerTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/playback/PlayerTest.kt
@@ -117,7 +117,6 @@ class PlayerTest {
     }
 
     verifySequence {
-      mockPlaybackStrategy.pause()
       mockPlaybackStrategy.stop()
       strategy2.setVolume(any())
     }
@@ -136,7 +135,6 @@ class PlayerTest {
 
     verifySequence {
       mockPlaybackStrategy.play() // from initial play call
-      mockPlaybackStrategy.pause()
       mockPlaybackStrategy.stop()
       strategy2.setVolume(any())
     }
@@ -163,7 +161,6 @@ class PlayerTest {
 
     verifySequence {
       mockPlaybackStrategy.play() // from initial play call
-      mockPlaybackStrategy.pause()
       mockPlaybackStrategy.stop()
       strategy2.setVolume(any())
       strategy2.play()

--- a/app/src/test/java/com/github/ashutoshgngwr/noice/playback/strategy/LocalPlaybackStrategyTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/playback/strategy/LocalPlaybackStrategyTest.kt
@@ -11,8 +11,6 @@ import io.mockk.impl.annotations.OverrideMockKs
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,13 +49,7 @@ class LocalPlaybackStrategyTest {
     every { mockPlayer.repeatMode } returns ExoPlayer.REPEAT_MODE_ONE
     playbackStrategy.setVolume(1f)
     playbackStrategy.play()
-
-    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
     verify(exactly = 1) { mockPlayer.playWhenReady = true }
-    val volumeSlots = mutableListOf<Float>()
-    verify { mockPlayer.volume = capture(volumeSlots) }
-    assertTrue("volume should increase with each step", volumeSlots.first() < volumeSlots.last())
-    assertEquals("volume should be set to desired value on finish", 1f, volumeSlots.last())
   }
 
   @Test
@@ -98,10 +90,5 @@ class LocalPlaybackStrategyTest {
       mockPlayer.playWhenReady = false
       mockPlayer.release()
     }
-
-    val volumeSlots = mutableListOf<Float>()
-    verify(atLeast = 3) { mockPlayer.volume = capture(volumeSlots) }
-    assertTrue("volume should decrease with each step", volumeSlots.first() > volumeSlots.last())
-    assertEquals("volume should be set to desired value on finish", 0f, volumeSlots.last())
   }
 }

--- a/app/src/testFdroid/java/com/github/ashutoshgngwr/noice/provider/GitHubReviewFlowProviderTest.kt
+++ b/app/src/testFdroid/java/com/github/ashutoshgngwr/noice/provider/GitHubReviewFlowProviderTest.kt
@@ -74,7 +74,7 @@ class GitHubReviewFlowProviderTest {
       mockPrefs.getBoolean(GitHubReviewFlowProvider.PREF_FLOW_SUCCESSFULLY_COMPLETED, any())
     } returns true
 
-    PreferenceManager.getDefaultSharedPreferences(fragmentActivity).edit(commit = true) {
+    PreferenceManager.getDefaultSharedPreferences(fragmentActivity).edit {
       putBoolean(GitHubReviewFlowProvider.PREF_FLOW_SUCCESSFULLY_COMPLETED, true)
     }
 


### PR DESCRIPTION
This PR proposes changes for allowing playback to be transferred to different audio streams in general. Wake-up timers are the only use-case where this behaviour is needed as of now. 

### Changes
<!-- Please describe your changes to provide additional context. -->
- [x] Add methods to specify and change audio stream in PlayerManager
- [x] Add intent extra to specify audio stream in play preset action in MediaPlayerService
- [x] Use alarm stream to play presets in Wake-up timers
- [x] Revert audio stream to normal when the user stops the preset played by the wake-up timer

### Testing
- [x] Tested on a physical device
- [x] Added or modified unit test cases